### PR TITLE
✨ Query improvements & ♻️ Large improvement of structure

### DIFF
--- a/Jotform/Endpoints/Form/GetFormQuestions.cs
+++ b/Jotform/Endpoints/Form/GetFormQuestions.cs
@@ -2,7 +2,7 @@
 
 public partial class JotformClient
 {
-    public async Task<JotformResult<Dictionary<string, Question>>?> GetFormQuestionsAsync(string formId, CancellationToken cancellationToken = default) 
-        => await _httpClient.GetFromJsonAsync<JotformResult<Dictionary<string, Question>>>($"form/{formId}/questions",
-            _jsonSerializerOptions, cancellationToken: cancellationToken);
+    public Task<JotformResult<Dictionary<string, Question>>?> GetFormQuestionsAsync(string formId, CancellationToken cancellationToken = default) 
+        => GetResultAsync<Dictionary<string, Question>>(
+            $"form/{formId}/questions", cancellationToken);
 }

--- a/Jotform/Endpoints/Form/GetFormSubmissions.cs
+++ b/Jotform/Endpoints/Form/GetFormSubmissions.cs
@@ -2,7 +2,7 @@
 
 public partial class JotformClient
 {
-    public async Task<PagedJotformResult<FormSubmission>?> GetFormSubmissionsAsync(string formId, int? offset = null, int? limit = null, string? filter = null, string? orderBy = null, CancellationToken cancellationToken = default)
+    public Task<PagedJotformResult<FormSubmission>?> GetFormSubmissionsAsync(string formId, int? offset = null, int? limit = null, string? filter = null, string? orderBy = null, CancellationToken cancellationToken = default)
     {
         var url = new UriBuilder($"form/{formId}/submissions")
             .AddQuery("offset", offset)
@@ -10,7 +10,8 @@ public partial class JotformClient
             .AddQuery("filter", filter)
             .AddQuery("orderby", orderBy);
 
-        return await _httpClient.GetFromJsonAsync<PagedJotformResult<FormSubmission>>(url.ToString(), _jsonSerializerOptions, cancellationToken);
+        return GetPagedResultAsync<FormSubmission>(url.ToString(),
+            cancellationToken);
     }
 }
 public class FormSubmission

--- a/Jotform/Endpoints/User/GetUser.cs
+++ b/Jotform/Endpoints/User/GetUser.cs
@@ -7,9 +7,9 @@ public partial class JotformClient
     /// Get User Information
     /// Get user account details for this Jotform user. Including user account type, avatar URL, name, email, website URL.
     /// </summary>
-    public async Task<JotformResult<GetUserResponse>?> GetUserAsync(CancellationToken cancellationToken = default)
-        => await _httpClient.GetFromJsonAsync<JotformResult<GetUserResponse>>("user", 
-            _jsonSerializerOptions, cancellationToken: cancellationToken);
+    public Task<JotformResult<GetUserResponse>?> GetUserAsync(
+        CancellationToken cancellationToken = default)
+        => GetResultAsync<GetUserResponse>("user", cancellationToken);
 }
 
 public class GetUserResponse

--- a/Jotform/Endpoints/User/GetUserForms.cs
+++ b/Jotform/Endpoints/User/GetUserForms.cs
@@ -6,15 +6,16 @@ public partial class JotformClient
     /// Get User Forms
     /// Get a list of forms for this account. Includes basic details such as title of the form, when it was created, number of new and total submissions.
     /// </summary>
-    public async Task<PagedJotformResult<Models.Shared.Form>?> GetUserFormsAsync(int? offset = null, int? limit = null, string? jsonFilter = null, string? orderBy = null, CancellationToken cancellationToken = default)
+    public Task<PagedJotformResult<Models.Shared.Form>?> GetUserFormsAsync(int? offset = null, int? limit = null, string? jsonFilter = null, string? orderBy = null, CancellationToken cancellationToken = default)
     {
         var url = new UriBuilder("user/forms")
             .AddQuery("offset", offset)
             .AddQuery("limit", limit)
-            .AddQuery("jsonFilter", jsonFilter)
+            .AddQuery("filter", jsonFilter)
             .AddQuery("orderBy", orderBy)
             .ToString();
 
-        return await _httpClient.GetFromJsonAsync<PagedJotformResult<Models.Shared.Form>>(url, _jsonSerializerOptions, cancellationToken);
+        return GetPagedResultAsync<Models.Shared.Form>(
+            url, cancellationToken);
     }
 }

--- a/Jotform/Endpoints/User/GetUserSubmissions.cs
+++ b/Jotform/Endpoints/User/GetUserSubmissions.cs
@@ -1,5 +1,4 @@
-﻿
-namespace Jotform;
+﻿namespace Jotform;
 
 public partial class JotformClient
 {
@@ -7,7 +6,7 @@ public partial class JotformClient
     /// Get User Submissions
     /// Get a list of all submissions for all forms on this account. The answers array has the submission data. Created_at is the date of the submission.
     /// </summary>
-    public async Task<PagedJotformResult<GetUserSubmissionsResponse>?> GetUserSubmissionsAsync(int? offset = null, int? limit = null, string? filter = null, string? orderBy = null, CancellationToken cancellationToken = default)
+    public Task<PagedJotformResult<GetUserSubmissionsResponse>?> GetUserSubmissionsAsync(int? offset = null, int? limit = null, string? filter = null, string? orderBy = null, CancellationToken cancellationToken = default)
     {
         var url = new UriBuilder("user/submissions")
             .AddQuery("offset", offset)
@@ -15,7 +14,8 @@ public partial class JotformClient
             .AddQuery("filter", filter)
             .AddQuery("orderby", orderBy);
 
-        return await _httpClient.GetFromJsonAsync<PagedJotformResult<GetUserSubmissionsResponse>>(url.ToString(), _jsonSerializerOptions, cancellationToken);
+        return GetPagedResultAsync<GetUserSubmissionsResponse>(
+            url.ToString(), cancellationToken);
     }
 }
 

--- a/Jotform/Models/Shared/JotformFilterBuilder.cs
+++ b/Jotform/Models/Shared/JotformFilterBuilder.cs
@@ -1,0 +1,105 @@
+﻿using System.Text.Json;
+
+namespace Jotform.Models.Shared;
+
+public class JotformFilterBuilder
+{
+    protected readonly Dictionary<string, object> _fields = new();
+
+    public JotformFilterBuilder AddCriteria<TValue>(
+        string field, TValue? value)
+    {
+        if (value is null) return this;
+        if (value is DateTime dateTime)
+            _fields.Add(field, dateTime.ToString("yyyy-MM-dd hh:mm:ss"));
+        else
+            _fields.Add(field, value.ToString()!);
+
+        return this;
+    }
+
+    public JotformFilterBuilder AddCriteria(
+        string field, IEnumerable<string> values)
+    {
+        if (!values.Any()) return this;
+        _fields.Add(field, values);
+        return this;
+    }
+
+    public JotformFilterBuilder AddCriteria<TValue>(
+        string field, string comparision, TValue? value)
+    {
+        return AddCriteria(field + ":" + comparision, value);
+    }
+
+    public JotformFilterBuilder AddGreaterThan<TValue>(
+        string field, TValue? value)
+    {
+        return AddCriteria(field, "gt", value);
+    }
+
+    public JotformFilterBuilder AddLessThan<TValue>(
+        string field, TValue? value)
+    {
+        return AddCriteria(field, "lt", value);
+    }
+
+    public JotformFilterBuilder AddNotEqualTo<TValue>(
+        string field, TValue? value)
+    {
+        return AddCriteria(field, "ne", value);
+    }
+
+    public JotformFilterBuilder AddMatches<TValue>(
+        string field, TValue? value)
+    {
+        return AddCriteria(field, "matches", value);
+    }
+
+    public JotformFilterBuilder AddGreaterThan(
+        string field, DateTime? value, bool minusOneDay = false)
+    {
+        return AddCriteria(field, "gt", 
+            minusOneDay ? value?.AddDays(-1.0) : value);
+    }
+
+    public JotformFilterBuilder AddLessThan(
+        string field, DateTime? value, bool plusOneDay = false)
+    {
+        return AddCriteria(field, "lt", 
+            plusOneDay ? value?.AddDays(1.0) : value);
+    }
+
+    public JotformFilterBuilder AddDateRange(
+        string field, DateTime? start, DateTime? end, 
+        bool minusOneDayFromStart = true, 
+        bool plusOneDayToEnd = true)
+    {
+        return AddGreaterThan(field, start, minusOneDayFromStart)
+            .AddLessThan(field, end, plusOneDayToEnd);
+    }
+
+    public JotformFilterBuilder AddCreatedAtDateRange(
+        DateTime? start, DateTime? end, 
+        bool minusOneDayFromStart = true,
+        bool plusOneDayToEnd = true)
+    {
+        return AddDateRange("created_at", start, end,
+            minusOneDayFromStart, plusOneDayToEnd);
+    }
+
+    public JotformFilterBuilder AddUpdatedAtDateRange(
+        DateTime? start, DateTime? end,
+        bool minusOneDayFromStart = true,
+        bool plusOneDayToEnd = true)
+    {
+        return AddDateRange("updated_at", start, end,
+            minusOneDayFromStart, plusOneDayToEnd);
+    }
+
+    public string? Build()
+    {
+        if (_fields.Count == 0) return null;
+        return JsonSerializer.Serialize(_fields);
+    }
+}

--- a/Jotform/Models/Shared/UriBuilder.cs
+++ b/Jotform/Models/Shared/UriBuilder.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-
-namespace Jotform.Models.Shared;
+﻿namespace Jotform.Models.Shared;
 
 public class UriBuilder
 {
@@ -12,38 +10,21 @@ public class UriBuilder
         _baseUrl = baseUrl;
     }
 
-    public UriBuilder AddQuery(string parameter, object? value)
+    public UriBuilder AddQuery<TValue>(string parameter, TValue? value)
     {
-        if (value?.ToString() is null)
-        {
-            return this;
-        }
-
-        _parameters[parameter] = value.ToString()!;
-
-        return this;
-    }
-    public UriBuilder AddQuery(string parameter, string? value)
-    {
-        if (value is null)
-        {
-            return this;
-        }
-
-        _parameters[parameter] = value;
-
+        if (value is null) return this;
+        var stringValue = value.ToString();
+        if (stringValue == string.Empty) return this;
+        _parameters[parameter] = stringValue!;
         return this;
     }
 
     public override string ToString()
     {
+        if (_parameters.Count == 0) return _baseUrl;
+
         var query = string.Join("&", _parameters.Select(x => $"{x.Key}={x.Value}"));
 
-        if (string.IsNullOrWhiteSpace(query))
-        {
-            return _baseUrl;
-        }
-        
         return $"{_baseUrl}?{query}";
     }
 }

--- a/tests/Jotform.Tests/CreateClientTests.cs
+++ b/tests/Jotform.Tests/CreateClientTests.cs
@@ -1,12 +1,21 @@
-﻿namespace Jotform.Tests;
+﻿using Jotform.Tests.Fixtures;
 
+namespace Jotform.Tests;
+
+[Collection(nameof(HttpClientFixture))]
 public class CreateClientTests
 {
+    private static HttpClient GetClient()
+    {
+        return HttpClientFixture.ResetBaseAddress();
+    }
+
     [Fact]
     public void NewJotformClient_WithApiKey_ShouldNotError()
     {
         // Act
-        var jotformClient = new JotformClient("1234567890abcdef1234567890abcdef");
+        var jotformClient = new JotformClient(GetClient(),
+            "1234567890abcdef1234567890abcdef");
         
         // Assert
         jotformClient.Should().NotBeNull();
@@ -16,7 +25,8 @@ public class CreateClientTests
     public void NewJotformClient_WithEnterpriseSubdomain_ShouldNotError()
     {
         // Act
-        var jotformClient = new JotformClient("1234567890abcdef1234567890abcdef", "subdomain");
+        var jotformClient = new JotformClient(GetClient(),
+            "1234567890abcdef1234567890abcdef", "subdomain");
         
         // Assert
         jotformClient.Should().NotBeNull();

--- a/tests/Jotform.Tests/Fixtures/HttpClientFixture.cs
+++ b/tests/Jotform.Tests/Fixtures/HttpClientFixture.cs
@@ -1,0 +1,21 @@
+﻿namespace Jotform.Tests.Fixtures;
+
+public class HttpClientFixture : IDisposable
+{
+    public static HttpClient HttpClient { get; } = new();
+
+    public void Dispose()
+    {
+        HttpClient.Dispose();
+    }
+
+    public static HttpClient ResetBaseAddress()
+    {
+        HttpClient.BaseAddress = null;
+        return HttpClient;
+    }
+}
+
+[CollectionDefinition(nameof(HttpClientFixture))]
+public class HttpClientShared : ICollectionFixture<HttpClientFixture>
+{ }

--- a/tests/Jotform.Tests/Fixtures/JotformClientFixture.cs
+++ b/tests/Jotform.Tests/Fixtures/JotformClientFixture.cs
@@ -6,8 +6,9 @@ public static class JotformClientFixture
 {
     private static readonly string ApiKey;
     public static readonly string UserName;
-
-    public static JotformClient JotformClient => new(ApiKey);
+    
+    public static JotformClient JotformClient => new(
+        HttpClientFixture.ResetBaseAddress(), ApiKey);
 
     public static readonly string FormId;
     public static readonly string QuestionId;

--- a/tests/Jotform.Tests/JotformFilterBuilderTests.cs
+++ b/tests/Jotform.Tests/JotformFilterBuilderTests.cs
@@ -1,0 +1,173 @@
+﻿using Jotform.Models.Shared;
+
+namespace Jotform.Tests;
+
+public class JotformFilterBuilderTests
+{
+    [Fact]
+    public void Build_ReturnsNull_If_NoOtherMethodIsCalled()
+    {
+        var builder = new JotformFilterBuilder();
+        builder.Build().Should().BeNull();
+    }
+
+    [Fact]
+    public void Build_ReturnsNull_If_OtherMethodsAreCalledWithNulls()
+    {
+        var builder = new JotformFilterBuilder();
+        string? field1 = null;
+        int? field2 = null;
+        decimal? field3 = null;
+        
+        builder.AddCriteria("field1", field1);
+        builder.AddCriteria("field2", field2);
+        builder.AddCriteria("field3", field3);
+        
+        builder.Build().Should().BeNull();
+    }
+
+    [Fact]
+    public void Build_ReturnsValidJson_If_AddCriteria_IsCalledWithNonEmptyString()
+    {
+        var builder = new JotformFilterBuilder();
+        string? field = "value";
+        var jsonFilter = @"{""field"":""value""}";
+
+        builder.AddCriteria(nameof(field), field);
+
+        builder.Build().Should().Be(jsonFilter);
+    }
+
+    [Fact]
+    public void Build_ReturnsValidJson_If_AddCriteria_IsCalledWithValidInteger()
+    {
+        var builder = new JotformFilterBuilder();
+        int? field = 0;
+        var jsonFilter = @"{""field"":""0""}";
+
+        builder.AddCriteria(nameof(field), field);
+
+        builder.Build().Should().Be(jsonFilter);
+    }
+
+    [Fact]
+    public void Build_ReturnsValidJson_If_AddCriteria_IsCalledWithValidDecimal()
+    {
+        var builder = new JotformFilterBuilder();
+        decimal? field = 0.1M;
+        var jsonFilter = @"{""field"":""0.1""}";
+
+        builder.AddCriteria(nameof(field), field);
+
+        builder.Build().Should().Be(jsonFilter);
+    }
+
+    [Fact]
+    public void Build_ReturnsValidJson_If_AddCriteria_WithComparisionModifier_IsCalledWithNonEmptyString()
+    {
+        var builder = new JotformFilterBuilder();
+        const string comparision = "eq";
+        string? field = "value";
+        var jsonFilter = @"{""field:eq"":""value""}";
+
+        builder.AddCriteria(nameof(field), comparision, field);
+
+        builder.Build().Should().Be(jsonFilter);
+    }
+
+    [Fact]
+    public void Build_ReturnsValidJson_If_AddGreaterThan_IsCalledWithNonEmptyString()
+    {
+        var builder = new JotformFilterBuilder();
+        string? field = "value";
+        var jsonFilter = @"{""field:gt"":""value""}";
+
+        builder.AddGreaterThan(nameof(field), field);
+
+        builder.Build().Should().Be(jsonFilter);
+    }
+
+    [Fact]
+    public void Build_ReturnsValidJson_If_AddLessThan_IsCalledWithNonEmptyString()
+    {
+        var builder = new JotformFilterBuilder();
+        string? field = "value";
+        var jsonFilter = @"{""field:lt"":""value""}";
+
+        builder.AddLessThan(nameof(field), field);
+
+        builder.Build().Should().Be(jsonFilter);
+    }
+
+    [Fact]
+    public void Build_ReturnsValidJson_If_AddNotEqualTo_IsCalledWithNonEmptyString()
+    {
+        var builder = new JotformFilterBuilder();
+        string? field = "value";
+        var jsonFilter = @"{""field:ne"":""value""}";
+
+        builder.AddNotEqualTo(nameof(field), field);
+
+        builder.Build().Should().Be(jsonFilter);
+    }
+
+    [Fact]
+    public void Build_ReturnsValidJson_If_AddMatches_IsCalledWithNonEmptyString()
+    {
+        var builder = new JotformFilterBuilder();
+        string? field = "value";
+        var jsonFilter = @"{""field:matches"":""value""}";
+
+        builder.AddMatches(nameof(field), field);
+
+        builder.Build().Should().Be(jsonFilter);
+    }
+
+    [Fact]
+    public void Build_ReturnsValidJson_If_AddGreaterThan_IsCalledWithValidDate()
+    {
+        var builder = new JotformFilterBuilder();
+        DateTime? field = new DateTime(2024, 1, 1);
+        var jsonFilter = @$"{{""field:gt"":""2024-01-01 12:00:00""}}";
+        
+        builder.AddGreaterThan(nameof(field), field);
+
+        builder.Build().Should().Be(jsonFilter);
+    }
+
+    [Fact]
+    public void Build_ReturnsValidJson_If_AddGreaterThan_IsCalledWithValidDateAndMinusOneDayTrue()
+    {
+        var builder = new JotformFilterBuilder();
+        DateTime? field = new DateTime(2024, 1, 2);
+        var jsonFilter = @$"{{""field:gt"":""2024-01-01 12:00:00""}}";
+
+        builder.AddGreaterThan(nameof(field), field, true);
+
+        builder.Build().Should().Be(jsonFilter);
+    }
+
+    [Fact]
+    public void Build_ReturnsValidJson_If_AddLessThan_IsCalledWithValidDate()
+    {
+        var builder = new JotformFilterBuilder();
+        DateTime? field = new DateTime(2024, 1, 1);
+        var jsonFilter = @$"{{""field:lt"":""2024-01-01 12:00:00""}}";
+
+        builder.AddLessThan(nameof(field), field);
+
+        builder.Build().Should().Be(jsonFilter);
+    }
+
+    [Fact]
+    public void Build_ReturnsValidJson_If_AddLessThan_IsCalledWithValidDateAndPlusOneDayTrue()
+    {
+        var builder = new JotformFilterBuilder();
+        DateTime? field = new DateTime(2024, 1, 1);
+        var jsonFilter = @$"{{""field:lt"":""2024-01-02 12:00:00""}}";
+
+        builder.AddLessThan(nameof(field), field, true);
+
+        builder.Build().Should().Be(jsonFilter);
+    }
+}

--- a/tests/Jotform.Tests/SimpleIntegrationTests.cs
+++ b/tests/Jotform.Tests/SimpleIntegrationTests.cs
@@ -1,9 +1,9 @@
-using System.Net;
-using Jotform.Models.Shared;
 using Jotform.Tests.Fixtures;
+using System.Net;
 
 namespace Jotform.Tests;
 
+[Collection(nameof(HttpClientFixture))]
 public class SimpleIntegrationTests
 {
     [Fact]
@@ -92,10 +92,10 @@ public class SimpleIntegrationTests
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var folders = await jotformClient.GetUserFoldersAsync();
-        
+
         // Assert
         folders.Should().NotBeNull();
         folders!.Response.Forms.Should().HaveCountGreaterThan(0);
@@ -106,10 +106,10 @@ public class SimpleIntegrationTests
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var reports = await jotformClient.GetUserReportsAsync();
-        
+
         // Assert
         reports.Should().NotBeNull();
         reports!.Response.Should().HaveCount(0);
@@ -120,36 +120,36 @@ public class SimpleIntegrationTests
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         Func<Task> act = async () => await jotformClient.PostUserRegisterAsync("", "", "");
-        
+
         // Assert
         await act.Should().ThrowAsync<NotSupportedException>();
     }
-    
+
     [Fact]
     public async Task PostUserLogin_WithAny_ShouldThrowException()
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         Func<Task> act = async () => await jotformClient.PostUserLoginAsync("", "");
-        
+
         // Assert
         await act.Should().ThrowAsync<NotSupportedException>();
     }
-    
+
     [Fact]
     public async Task GetUserLogout_WithAny_ShouldThrowException()
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         Func<Task> act = async () => await jotformClient.GetUserLogoutAsync();
-        
+
         // Assert
         await act.Should().ThrowAsync<NotSupportedException>();
     }
@@ -159,39 +159,39 @@ public class SimpleIntegrationTests
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var settings = await jotformClient.GetUserSettingsAsync();
-        
+
         // Assert
         settings.Should().NotBeNull();
         settings!.ResponseCode.Should().Be(HttpStatusCode.OK);
         settings.Response.Should().NotBeNull();
     }
-    
+
     [Fact]
     public async Task PostUserSettings_WithReadOnly_ShouldThrowException()
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var result = await jotformClient.PostUserSettingsAsync(JotformClientFixture.UserName);
-        
+
         // Assert
         result.Should().NotBeNull();
         result!.Response.Name.Should().Be(JotformClientFixture.UserName);
     }
-    
+
     [Fact]
     public async Task GetUserHistory_WithDefaults_ReturnsObject()
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var history = await jotformClient.GetUserHistoryAsync();
-        
+
         // Assert
         history.Should().NotBeNull();
         history!.ResponseCode.Should().Be(HttpStatusCode.OK);
@@ -204,10 +204,10 @@ public class SimpleIntegrationTests
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var forms = await jotformClient.GetUserFormsAsync();
-        
+
         // Assert
         forms.Should().NotBeNull();
         forms!.ResponseCode.Should().Be(HttpStatusCode.OK);
@@ -220,10 +220,10 @@ public class SimpleIntegrationTests
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var form = await jotformClient.GetFormAsync(JotformClientFixture.FormId);
-        
+
         // Assert
         form.Should().NotBeNull();
         form!.ResponseCode.Should().Be(HttpStatusCode.OK);
@@ -236,10 +236,10 @@ public class SimpleIntegrationTests
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var questions = await jotformClient.GetFormQuestionsAsync(JotformClientFixture.FormId);
-        
+
         // Assert
         questions.Should().NotBeNull();
         questions!.ResponseCode.Should().Be(HttpStatusCode.OK);
@@ -253,10 +253,10 @@ public class SimpleIntegrationTests
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var question = await jotformClient.GetFormQuestionAsync(JotformClientFixture.FormId, JotformClientFixture.QuestionId);
-        
+
         // Assert
         question.Should().NotBeNull();
         question!.ResponseCode.Should().Be(HttpStatusCode.OK);
@@ -269,10 +269,10 @@ public class SimpleIntegrationTests
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var properties = await jotformClient.GetFormPropertiesAsync(JotformClientFixture.FormId);
-        
+
         // Assert
         properties.Should().NotBeNull();
         properties!.ResponseCode.Should().Be(HttpStatusCode.OK);
@@ -284,28 +284,28 @@ public class SimpleIntegrationTests
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
-        var property = await jotformClient.GetFormPropertyAsync(JotformClientFixture.FormId, 
+        var property = await jotformClient.GetFormPropertyAsync(JotformClientFixture.FormId,
             x => x.FormWidth);
-        
+
         // Assert
         property.Should().NotBeNull();
         property!.ResponseCode.Should().Be(HttpStatusCode.OK);
         property.Response.Should().NotBeNull();
         property.Response.FormWidth.Should().NotBe(default);
     }
-    
+
     [Fact]
     public async Task GetFormProperty_WithStringMemberExpression_ReturnsProperty()
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
-        var property = await jotformClient.GetFormPropertyAsync(JotformClientFixture.FormId, 
+        var property = await jotformClient.GetFormPropertyAsync(JotformClientFixture.FormId,
             x => x.Background);
-        
+
         // Assert
         property.Should().NotBeNull();
         property!.ResponseCode.Should().Be(HttpStatusCode.OK);
@@ -318,10 +318,10 @@ public class SimpleIntegrationTests
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var report = await jotformClient.GetFormReportsAsync(JotformClientFixture.FormId);
-        
+
         // Assert
         report.Should().NotBeNull();
         report!.ResponseCode.Should().Be(HttpStatusCode.OK);
@@ -333,10 +333,10 @@ public class SimpleIntegrationTests
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var files = await jotformClient.GetFormFilesAsync(JotformClientFixture.FormId);
-        
+
         // Assert
         files.Should().NotBeNull();
         files!.ResponseCode.Should().Be(HttpStatusCode.OK);
@@ -348,25 +348,25 @@ public class SimpleIntegrationTests
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var webhooks = await jotformClient.GetFormWebhooksAsync(JotformClientFixture.FormId);
-        
+
         // Assert
         webhooks.Should().NotBeNull();
         webhooks!.ResponseCode.Should().Be(HttpStatusCode.OK);
         webhooks.Response.Should().NotBeNull();
     }
-    
+
     [Fact]
     public async Task GetFormSubmissions_WithFormId_ReturnsList()
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var submissions = await jotformClient.GetFormSubmissionsAsync(JotformClientFixture.FormId);
-        
+
         // Assert
         submissions.Should().NotBeNull();
         submissions!.ResponseCode.Should().Be(HttpStatusCode.OK);
@@ -378,10 +378,10 @@ public class SimpleIntegrationTests
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var submission = await jotformClient.GetSubmissionAsync(JotformClientFixture.SubmissionId);
-        
+
         // Assert
         submission.Should().NotBeNull();
         submission!.ResponseCode.Should().Be(HttpStatusCode.OK);
@@ -394,22 +394,22 @@ public class SimpleIntegrationTests
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var folder = await jotformClient.GetFolderAsync(JotformClientFixture.FolderId);
-        
+
         // Assert
         folder.Should().NotBeNull();
         folder!.ResponseCode.Should().Be(HttpStatusCode.OK);
         folder.Response.Should().NotBeNull();
         folder.Response.Id.Should().Be(JotformClientFixture.FolderId);
     }
-    
+
     // Member data to get all enum values of SystemPlanType
     public static IEnumerable<object[]> SystemPlanTypeValues() =>
         Enum.GetValues(typeof(SystemPlanType))
             .Cast<SystemPlanType>()
-            .Select(x => new object[] {x});
+            .Select(x => new object[] { x });
 
     [Theory]
     [MemberData(nameof(SystemPlanTypeValues))]
@@ -417,14 +417,14 @@ public class SimpleIntegrationTests
     {
         // Arrange
         var jotformClient = JotformClientFixture.JotformClient;
-        
+
         // Act
         var plan = await jotformClient.GetSystemPlanAsync(type);
-        
+
         // Assert
         plan.Should().NotBeNull();
         plan!.ResponseCode.Should().Be(HttpStatusCode.OK);
         plan.Response.Should().NotBeNull();
-        
+
     }
 }

--- a/tests/Jotform.Tests/UriBuilderTests.cs
+++ b/tests/Jotform.Tests/UriBuilderTests.cs
@@ -1,0 +1,84 @@
+﻿namespace Jotform.Tests;
+
+public class UriBuilderTests
+{
+    private const string BASE_URL = "http://example.com";
+
+    [Fact]
+    public void ToString_ReturnsBaseUrl_If_AddQuery_IsNeverCalled()
+    {
+        var builder = new UriBuilder(BASE_URL);
+        builder.ToString().Should().Be(BASE_URL);
+    }
+
+    [Fact]
+    public void ToString_ReturnsBaseUrl_If_AddQuery_IsCalledWithNulls()
+    {
+        var builder = new UriBuilder(BASE_URL);
+        string? param1 = null;
+        int? param2 = null;
+        decimal? param3 = null;
+
+        builder.AddQuery("param1", param1);
+        builder.AddQuery("param2", param2);
+        builder.AddQuery("param3", param3);
+
+        builder.ToString().Should().Be(BASE_URL);
+    }
+
+    [Fact]
+    public void ToString_ReturnsUrlWithQuery_If_AddQuery_IsCalledWithNonEmptyString()
+    {        
+        var builder = new UriBuilder(BASE_URL);
+        string? param = "value";
+        var query = $"param=value";
+        var urlWithQuery = $"{BASE_URL}?{query}";
+
+        builder.AddQuery(nameof(param), param);
+
+        builder.ToString().Should().Be(urlWithQuery);
+    }
+
+    [Fact]
+    public void ToString_ReturnsUrlWithQuery_If_AddQuery_IsCalledWithValidInteger()
+    {
+        var builder = new UriBuilder(BASE_URL);
+        int? param = 0;
+        var query = $"param=0";
+        var urlWithQuery = $"{BASE_URL}?{query}";
+
+        builder.AddQuery(nameof(param), param);
+
+        builder.ToString().Should().Be(urlWithQuery);
+    }
+
+    [Fact]
+    public void ToString_ReturnsUrlWithQuery_If_AddQuery_IsCalledWithValidDecimal()
+    {
+        var builder = new UriBuilder(BASE_URL);
+        decimal? param = 0.1M;
+        var query = $"param=0.1";
+        var urlWithQuery = $"{BASE_URL}?{query}";
+
+        builder.AddQuery(nameof(param), param);
+
+        builder.ToString().Should().Be(urlWithQuery);
+    }
+
+    [Fact]
+    public void ToString_ReturnsUrlWithQuery_If_AddQuery_IsCalledWithNonNulls()
+    {
+        var builder = new UriBuilder(BASE_URL);
+        string? param1 = "value";
+        int? param2 = 0;
+        decimal? param3 = 0.1M;
+        var query = $"param1=value&param2=0&param3=0.1";
+        var urlWithQuery = $"{BASE_URL}?{query}";
+
+        builder.AddQuery("param1", param1);
+        builder.AddQuery("param2", param2);
+        builder.AddQuery("param3", param3);
+ 
+        builder.ToString().Should().Be(urlWithQuery);
+    }
+}

--- a/tests/Jotform.Tests/Usings.cs
+++ b/tests/Jotform.Tests/Usings.cs
@@ -1,2 +1,3 @@
 global using Xunit;
 global using FluentAssertions;
+global using UriBuilder = Jotform.Models.Shared.UriBuilder;


### PR DESCRIPTION
- Updated the constructor to have the HttpClient injected instead of initiating it.
- Removed the _apiKey field as it was not used anywhere and only needed in Http headers.
- Added two helper methods GetResultAsync and GetPagedResultAsync
- Updated some endpoints (e.g. GetUser, GetUserForms, GetUserSubmissions, GetFormQuestions, GetFormSubmissions) to use the newly added helper methods. Also removed the async/await keywords in updated endpoints, I will update the other endpoints in another PR.

UriBuilder:
- Added a generic AddQuery method to avoid some boxing.
- Removed the AddQuery object and string methods in favour of generic.

JotformFilterBuilder: 
- Added a new class. 
- There're a couple of filter commands currently missing (e.g. fullText, and formIDs, supported in user-submissions filter https://api.jotform.com/docs/#user-submissions) I'll get these added as a subclass in another PR.


Tests:
- Updated the CreateClientTests, JotformClientFixture for accepting the HttpClient as dependency instead of initiating it.
- Added HttpClientFixture, UriBuilderTests and JotformFilterBuilderTests classes.

For the tests, I added `HttpClientFixture` as a workaround for holding singleton `HttpClient` throughout all the tests, Currently, I think XUnit doesn't support global setup/tear down, the only thing I could find is `[CollectionDefinition]` (which I'm using in this PR). XUnit V3 seems to have assembly-level setup/tear down. I will update this once V3 is available.