### PR TITLE
Few more updates

### DIFF
--- a/Jotform/Endpoints/Folder/GetFolder.cs
+++ b/Jotform/Endpoints/Folder/GetFolder.cs
@@ -2,7 +2,7 @@
 
 public partial class JotformClient
 {
-    public async Task<JotformResult<Folder>?> GetFolderAsync(string folderId, CancellationToken cancellationToken = default) 
-        => await _httpClient.GetFromJsonAsync<JotformResult<Folder>>($"folder/{folderId}", 
-            _jsonSerializerOptions, cancellationToken);
+    public Task<JotformResult<Folder>?> GetFolderAsync(string folderId, CancellationToken cancellationToken = default) 
+        => GetResultAsync<Folder>($"folder/{folderId}",
+            cancellationToken);
 }

--- a/Jotform/Endpoints/Form/GetForm.cs
+++ b/Jotform/Endpoints/Form/GetForm.cs
@@ -2,7 +2,7 @@
 
 public partial class JotformClient
 {
-    public async Task<JotformResult<Models.Shared.Form>?> GetFormAsync(string formId, CancellationToken cancellationToken = default) 
-        => await _httpClient.GetFromJsonAsync<JotformResult<Models.Shared.Form>>($"form/{formId}", 
-            _jsonSerializerOptions, cancellationToken: cancellationToken);
+    public Task<JotformResult<Models.Shared.Form>?> GetFormAsync(string formId, CancellationToken cancellationToken = default) 
+        => GetResultAsync<Models.Shared.Form>($"form/{formId}",
+            cancellationToken);
 }

--- a/Jotform/Endpoints/Form/GetFormFiles.cs
+++ b/Jotform/Endpoints/Form/GetFormFiles.cs
@@ -2,10 +2,9 @@
 
 public partial class JotformClient
 {
-    public async Task<JotformResult<FormFile[]>?> GetFormFilesAsync(string formId, CancellationToken cancellationToken = default)
-    {
-        return await _httpClient.GetFromJsonAsync<JotformResult<FormFile[]>>($"form/{formId}/files", _jsonSerializerOptions, cancellationToken);
-    }
+    public Task<JotformResult<FormFile[]>?> GetFormFilesAsync(string formId, CancellationToken cancellationToken = default) 
+        => GetResultAsync<FormFile[]>($"form/{formId}/files",
+            cancellationToken);
 }
 
 public class FormFile

--- a/Jotform/Endpoints/Form/GetFormProperties.cs
+++ b/Jotform/Endpoints/Form/GetFormProperties.cs
@@ -2,9 +2,9 @@
 
 public partial class JotformClient
 {
-    public async Task<JotformResult<FormProperties>?> GetFormPropertiesAsync(string formId, CancellationToken cancellationToken = default) 
-        => await _httpClient.GetFromJsonAsync<JotformResult<FormProperties>>($"form/{formId}/properties", 
-            _jsonSerializerOptions, cancellationToken);
+    public Task<JotformResult<FormProperties>?> GetFormPropertiesAsync(string formId, CancellationToken cancellationToken = default) 
+        => GetResultAsync<FormProperties>($"form/{formId}/properties",
+            cancellationToken);
 }
 
 public class Coupon

--- a/Jotform/Endpoints/Form/GetFormQuestion.cs
+++ b/Jotform/Endpoints/Form/GetFormQuestion.cs
@@ -2,7 +2,5 @@
 
 public partial class JotformClient
 {
-    public async Task<JotformResult<Question>?> GetFormQuestionAsync(string formId, string questionId, CancellationToken cancellationToken = default) 
-        => await _httpClient.GetFromJsonAsync<JotformResult<Question>>($"form/{formId}/question/{questionId}", 
-            _jsonSerializerOptions, cancellationToken);
+    public Task<JotformResult<Question>?> GetFormQuestionAsync(string formId, string questionId, CancellationToken cancellationToken = default) => GetResultAsync<Question>($"form/{formId}/question/{questionId}", cancellationToken);
 }

--- a/Jotform/Endpoints/Form/GetFormReports.cs
+++ b/Jotform/Endpoints/Form/GetFormReports.cs
@@ -2,9 +2,9 @@
 
 public partial class JotformClient
 {
-    public async Task<JotformResult<FormReport[]>?> GetFormReportsAsync(string formId, CancellationToken cancellationToken = default) 
-        => await _httpClient.GetFromJsonAsync<JotformResult<FormReport[]>>($"form/{formId}/reports", 
-            _jsonSerializerOptions, cancellationToken);
+    public Task<JotformResult<FormReport[]>?> GetFormReportsAsync(string formId, CancellationToken cancellationToken = default) 
+        => GetResultAsync<FormReport[]>($"form/{formId}/reports",
+            cancellationToken);
 }
 
 public class FormReport

--- a/Jotform/Endpoints/Report/GetReport.cs
+++ b/Jotform/Endpoints/Report/GetReport.cs
@@ -2,7 +2,7 @@
 
 public partial class JotformClient 
 {
-    public async Task<JotformResult<FormReport>?> GetReportAsync(string reportId, CancellationToken cancellationToken = default) 
-        => await _httpClient.GetFromJsonAsync<JotformResult<FormReport>>($"report/{reportId}", 
-            _jsonSerializerOptions, cancellationToken);
+    public Task<JotformResult<FormReport>?> GetReportAsync(string reportId, CancellationToken cancellationToken = default) 
+        => GetResultAsync<FormReport>($"report/{reportId}",
+            cancellationToken);
 }

--- a/Jotform/Endpoints/Submission/GetSubmission.cs
+++ b/Jotform/Endpoints/Submission/GetSubmission.cs
@@ -2,7 +2,7 @@
 
 public partial class JotformClient
 {
-    public async Task<JotformResult<FormSubmission>?> GetSubmissionAsync(string submissionId, CancellationToken cancellationToken = default) 
-        => await _httpClient.GetFromJsonAsync<JotformResult<FormSubmission>>($"submission/{submissionId}", 
-            _jsonSerializerOptions, cancellationToken);
+    public Task<JotformResult<FormSubmission>?> GetSubmissionAsync(string submissionId, CancellationToken cancellationToken = default) 
+        => GetResultAsync<FormSubmission>($"submission/{submissionId}",
+            cancellationToken);
 }

--- a/Jotform/Endpoints/System/GetSystemPlan.cs
+++ b/Jotform/Endpoints/System/GetSystemPlan.cs
@@ -2,9 +2,9 @@
 
 public partial class JotformClient
 {
-    public async Task<JotformResult<SystemPlan>?> GetSystemPlanAsync(SystemPlanType plan, CancellationToken cancellationToken = default) 
-        => await _httpClient.GetFromJsonAsync<JotformResult<SystemPlan>>($"system/plan/{plan.ToString().ToUpper()}", 
-            _jsonSerializerOptions, cancellationToken: cancellationToken);
+    public Task<JotformResult<SystemPlan>?> GetSystemPlanAsync(SystemPlanType plan, CancellationToken cancellationToken = default)
+        => GetResultAsync<SystemPlan>($"system/plan/{plan.ToString()
+            .ToUpper()}", cancellationToken);
 }
 
 public enum SystemPlanType

--- a/Jotform/Endpoints/User/GetSubUsers.cs
+++ b/Jotform/Endpoints/User/GetSubUsers.cs
@@ -2,8 +2,9 @@
 
 public partial class JotformClient
 {
-    public async Task<JotformResult<GetSubUsersResponse[]>?> GetSubUsersAsync(CancellationToken cancellationToken = default)
-        => await _httpClient.GetFromJsonAsync<JotformResult<GetSubUsersResponse[]>>("user/subusers", _jsonSerializerOptions, cancellationToken: cancellationToken);
+    public Task<JotformResult<GetSubUsersResponse[]>?> GetSubUsersAsync(CancellationToken cancellationToken = default)
+        => GetResultAsync<GetSubUsersResponse[]>("user/subusers",
+            cancellationToken);
 }
 
 public enum PermissionType

--- a/Jotform/Endpoints/User/GetUserFolders.cs
+++ b/Jotform/Endpoints/User/GetUserFolders.cs
@@ -2,8 +2,9 @@
 
 public partial class JotformClient
 {
-    public async Task<JotformResult<GetUserFoldersResponse>?> GetUserFoldersAsync(CancellationToken cancellationToken = default)
-        => await _httpClient.GetFromJsonAsync<JotformResult<GetUserFoldersResponse>>("user/folders", _jsonSerializerOptions, cancellationToken: cancellationToken);
+    public Task<JotformResult<GetUserFoldersResponse>?> GetUserFoldersAsync(CancellationToken cancellationToken = default)
+        => GetResultAsync<GetUserFoldersResponse>("user/folders",
+            cancellationToken);
 }
 
     public class Form

--- a/Jotform/Endpoints/User/GetUserHistory.cs
+++ b/Jotform/Endpoints/User/GetUserHistory.cs
@@ -2,7 +2,7 @@
 
 public partial class JotformClient
 {
-    public async Task<JotformResult<HistoryLog[]>?> GetUserHistoryAsync(HistoryAction? action = null, HistoryDate? date = null, string? startDate = null, string? endDate = null,
+    public Task<JotformResult<HistoryLog[]>?> GetUserHistoryAsync(HistoryAction? action = null, HistoryDate? date = null, string? startDate = null, string? endDate = null,
         CancellationToken cancellationToken = default)
     {
         var url = new UriBuilder("user/history")
@@ -12,7 +12,7 @@ public partial class JotformClient
             .AddQuery("endDate", endDate)
             .ToString();
 
-        return await _httpClient.GetFromJsonAsync<JotformResult<HistoryLog[]>>(url, _jsonSerializerOptions, cancellationToken);
+        return GetResultAsync<HistoryLog[]>(url, cancellationToken);
     }
 }
 

--- a/Jotform/Endpoints/User/GetUserReports.cs
+++ b/Jotform/Endpoints/User/GetUserReports.cs
@@ -3,8 +3,9 @@
 public partial class JotformClient
 {
     // TODO: Returns pagination info, but does not take them as parameters
-    public async Task<JotformResult<GetUserReportsResponse[]>?> GetUserReportsAsync(CancellationToken cancellationToken = default)
-        => await _httpClient.GetFromJsonAsync<JotformResult<GetUserReportsResponse[]>>("user/reports", _jsonSerializerOptions, cancellationToken);
+    public Task<JotformResult<GetUserReportsResponse[]>?> GetUserReportsAsync(CancellationToken cancellationToken = default)
+        => GetResultAsync<GetUserReportsResponse[]>("user/reports",
+            cancellationToken);
 }
 
 public class GetUserReportsResponse

--- a/Jotform/Endpoints/User/GetUserSettings.cs
+++ b/Jotform/Endpoints/User/GetUserSettings.cs
@@ -2,6 +2,7 @@
 
 public partial class JotformClient
 {
-    public async Task<JotformResult<UserSettings>?> GetUserSettingsAsync(CancellationToken cancellationToken = default)
-        => await _httpClient.GetFromJsonAsync<JotformResult<UserSettings>>("user/settings", _jsonSerializerOptions, cancellationToken: cancellationToken);
+    public Task<JotformResult<UserSettings>?> GetUserSettingsAsync(CancellationToken cancellationToken = default)
+        => GetResultAsync<UserSettings>("user/settings",
+            cancellationToken);
 }

--- a/Jotform/Endpoints/User/GetUserUsage.cs
+++ b/Jotform/Endpoints/User/GetUserUsage.cs
@@ -35,7 +35,7 @@ public class GetUserUsageResponse
     /// Total disk space used for uploaded files. In bytes.
     /// </summary>
     [JsonPropertyName("uploads")]
-    public int Uploads { get; set; }
+    public long Uploads { get; set; }
 
     /// <summary>
     /// Number of mobile submissions received this month

--- a/Jotform/Endpoints/User/GetUserUsage.cs
+++ b/Jotform/Endpoints/User/GetUserUsage.cs
@@ -6,9 +6,9 @@ public partial class JotformClient
     /// Get Monthly User Usage
     /// Get number of form submissions received this month. Also, get number of SSL form submissions, payment form submissions and upload space used by user.
     /// </summary>
-    public async Task<JotformResult<GetUserUsageResponse>?> GetUserUsageAsync(CancellationToken cancellationToken = default)
-        => await _httpClient.GetFromJsonAsync<JotformResult<GetUserUsageResponse>>("user/usage", 
-            _jsonSerializerOptions, cancellationToken: cancellationToken);
+    public Task<JotformResult<GetUserUsageResponse>?> GetUserUsageAsync(CancellationToken cancellationToken = default)
+        => GetResultAsync<GetUserUsageResponse>("user/usage",
+            cancellationToken);
 }
 
 public class GetUserUsageResponse

--- a/Jotform/Extensions.cs
+++ b/Jotform/Extensions.cs
@@ -1,0 +1,13 @@
+﻿#if NETSTANDARD2_0
+namespace Jotform;
+
+public static class Extensions
+{
+    public static void Deconstruct<T1, T2>(
+        this KeyValuePair<T1, T2> tuple, out T1 key, out T2 value)
+    {
+        key = tuple.Key;
+        value = tuple.Value;
+    }
+}
+#endif

--- a/Jotform/Jotform.csproj
+++ b/Jotform/Jotform.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+        <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
@@ -12,5 +13,10 @@
         <Authors>Luke Parker</Authors>
         <Company>LukeParkerDev</Company>
     </PropertyGroup>
+    
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+      <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
+      <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    </ItemGroup>
 
 </Project>

--- a/tests/Jotform.Tests/Fixtures/JotformClientFixture.cs
+++ b/tests/Jotform.Tests/Fixtures/JotformClientFixture.cs
@@ -6,9 +6,8 @@ public static class JotformClientFixture
 {
     private static readonly string ApiKey;
     public static readonly string UserName;
-    
-    public static JotformClient JotformClient => new(
-        HttpClientFixture.ResetBaseAddress(), ApiKey);
+
+    public static JotformClient JotformClient { get; }
 
     public static readonly string FormId;
     public static readonly string QuestionId;
@@ -26,5 +25,8 @@ public static class JotformClientFixture
         QuestionId = configuration["QuestionId"] ?? throw new InvalidOperationException();
         SubmissionId = configuration["SubmissionId"] ?? throw new InvalidOperationException();
         FolderId = configuration["FolderId"] ?? throw new InvalidOperationException();
+
+        JotformClient = new(HttpClientFixture.ResetBaseAddress(),
+            ApiKey!);
     }
 }


### PR DESCRIPTION
Updated the TFM to Net 8 + NetStandard 2.0 (for extending support to more platforms e.g. Net Framework).

[Tests] Updated the fixture to create and resue the `JotformClient` instance throughout all tests.
[Fix] Changed the `GetUserUsageResponse.Uploads` property to long (from int), as I've got a failing test because the upload number went higher than int.

Updated all GET endpoints (except the two, `GetFormPropertyAsync` and `GetFormWebhooksAsync`) to return the task without async/await and use the `GetResultAsync` helper method.