### PR TITLE
Nullablity warnings fixes, ConfigureAwait(false) Updates, Doc Comment Updates.

### DIFF
--- a/Jotform/Endpoints/Folder/DeleteFolder.cs
+++ b/Jotform/Endpoints/Folder/DeleteFolder.cs
@@ -2,6 +2,10 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Delete a folder and its subfolders.
+    /// </summary>
+    /// <param name="folderId">ID of the folder.</param>
     public async Task<JotformResult<string>?> DeleteFolderAsync(string folderId, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.DeleteAsync($"folder/{folderId}", cancellationToken).ConfigureAwait(false);

--- a/Jotform/Endpoints/Folder/DeleteFolder.cs
+++ b/Jotform/Endpoints/Folder/DeleteFolder.cs
@@ -4,10 +4,11 @@ public partial class JotformClient
 {
     public async Task<JotformResult<string>?> DeleteFolderAsync(string folderId, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.DeleteAsync($"folder/{folderId}", cancellationToken);
+        var response = await _httpClient.DeleteAsync($"folder/{folderId}", cancellationToken).ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<JotformResult<string>>(_jsonSerializerOptions, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<string>>(_jsonSerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/Jotform/Endpoints/Folder/GetFolder.cs
+++ b/Jotform/Endpoints/Folder/GetFolder.cs
@@ -2,6 +2,10 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Get a list of forms in a folder, and other details about the form such as folder color.
+    /// </summary>
+    /// <param name="folderId">Folder ID.</param>
     public Task<JotformResult<Folder>?> GetFolderAsync(string folderId, CancellationToken cancellationToken = default) 
         => GetResultAsync<Folder>($"folder/{folderId}",
             cancellationToken);

--- a/Jotform/Endpoints/Folder/PostFolder.cs
+++ b/Jotform/Endpoints/Folder/PostFolder.cs
@@ -2,6 +2,12 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Create a folder with specified parameters.
+    /// </summary>
+    /// <param name="folderName">Name of the folder.</param>
+    /// <param name="parentId">Parent id of the folder to be created.</param>
+    /// <param name="colorHex">Color of the folder Example: #FFFFFF</param>
     public async Task<JotformResult<Folder>?> PostFolderAsync(string folderName, string? parentId = null, string? colorHex = null, CancellationToken cancellationToken = default)
     {
         var formData = new FormDataBuilder();

--- a/Jotform/Endpoints/Folder/PostFolder.cs
+++ b/Jotform/Endpoints/Folder/PostFolder.cs
@@ -10,10 +10,12 @@ public partial class JotformClient
         formData.Add("parent", parentId);
         formData.Add("color", colorHex);
         
-        var response = await _httpClient.PostAsync("folder", formData.Build(), cancellationToken);
+        var response = await _httpClient.PostAsync("folder", formData.Build(), cancellationToken)
+            .ConfigureAwait(false);
         
         response.EnsureSuccessStatusCode();
         
-        return await response.Content.ReadFromJsonAsync<JotformResult<Folder>>(_jsonSerializerOptions, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<Folder>>(_jsonSerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/Jotform/Endpoints/Folder/PutFolder.cs
+++ b/Jotform/Endpoints/Folder/PutFolder.cs
@@ -2,6 +2,11 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Update a folder with specified parameters. Also you can add forms to the folder.
+    /// </summary>
+    /// <param name="folderId">ID of the folder.</param>
+    /// <param name="folder">FolderContent e.g. Name, color, parent of the specified folder. Also you can move forms to the specified folder.</param>
     public async Task<JotformResult<object>?> PutFolderAsync(string folderId, object folder, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.PutAsJsonAsync($"folder/{folderId}", folder, cancellationToken)

--- a/Jotform/Endpoints/Folder/PutFolder.cs
+++ b/Jotform/Endpoints/Folder/PutFolder.cs
@@ -4,10 +4,12 @@ public partial class JotformClient
 {
     public async Task<JotformResult<object>?> PutFolderAsync(string folderId, object folder, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.PutAsJsonAsync($"folder/{folderId}", folder, cancellationToken);
+        var response = await _httpClient.PutAsJsonAsync($"folder/{folderId}", folder, cancellationToken)
+            .ConfigureAwait(false);
         
         response.EnsureSuccessStatusCode();
         
-        return await response.Content.ReadFromJsonAsync<JotformResult<object>>(_jsonSerializerOptions, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<object>>(_jsonSerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/Jotform/Endpoints/Form/DeleteForm.cs
+++ b/Jotform/Endpoints/Form/DeleteForm.cs
@@ -4,10 +4,12 @@ public partial class JotformClient
 {
     public async Task<JotformResult<Models.Shared.Form>?> DeleteFormAsync(string formId, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.DeleteAsync($"form/{formId}", cancellationToken: cancellationToken);
+        var response = await _httpClient.DeleteAsync($"form/{formId}", cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<JotformResult<Models.Shared.Form>>(_jsonSerializerOptions, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<Models.Shared.Form>>(_jsonSerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/Jotform/Endpoints/Form/DeleteForm.cs
+++ b/Jotform/Endpoints/Form/DeleteForm.cs
@@ -2,6 +2,10 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Delete an existing form.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
     public async Task<JotformResult<Models.Shared.Form>?> DeleteFormAsync(string formId, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.DeleteAsync($"form/{formId}", cancellationToken: cancellationToken)

--- a/Jotform/Endpoints/Form/DeleteFormQuestion.cs
+++ b/Jotform/Endpoints/Form/DeleteFormQuestion.cs
@@ -2,6 +2,11 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Delete a single form question.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
+    /// <param name="questionId">Question ID.</param>
     public async Task<JotformResult<string>?> DeleteFormQuestionAsync(string formId, string questionId, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.DeleteAsync($"form/{formId}/question/{questionId}", cancellationToken)

--- a/Jotform/Endpoints/Form/DeleteFormQuestion.cs
+++ b/Jotform/Endpoints/Form/DeleteFormQuestion.cs
@@ -4,10 +4,12 @@ public partial class JotformClient
 {
     public async Task<JotformResult<string>?> DeleteFormQuestionAsync(string formId, string questionId, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.DeleteAsync($"form/{formId}/question/{questionId}", cancellationToken);
+        var response = await _httpClient.DeleteAsync($"form/{formId}/question/{questionId}", cancellationToken)
+            .ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<JotformResult<string>>(_jsonSerializerOptions, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<string>>(_jsonSerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/Jotform/Endpoints/Form/DeleteFormWebhook.cs
+++ b/Jotform/Endpoints/Form/DeleteFormWebhook.cs
@@ -4,6 +4,11 @@ namespace Jotform;
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Delete a webhook of a specific form
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
+    /// <param name="webhookId">Webhook ID.</param>
     public async Task<JotformResult<Dictionary<string, string>>?> DeleteFormWebhookAsync(string formId, string webhookId, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.DeleteAsync($"form/{formId}/webhooks/{webhookId}", cancellationToken)

--- a/Jotform/Endpoints/Form/DeleteFormWebhook.cs
+++ b/Jotform/Endpoints/Form/DeleteFormWebhook.cs
@@ -6,13 +6,15 @@ public partial class JotformClient
 {
     public async Task<JotformResult<Dictionary<string, string>>?> DeleteFormWebhookAsync(string formId, string webhookId, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.DeleteAsync($"form/{formId}/webhooks/{webhookId}", cancellationToken);
+        var response = await _httpClient.DeleteAsync($"form/{formId}/webhooks/{webhookId}", cancellationToken)
+            .ConfigureAwait(false);
         
         response.EnsureSuccessStatusCode();
 
         try
         {
-            return await response.Content.ReadFromJsonAsync<JotformResult<Dictionary<string, string>>>(_jsonSerializerOptions, cancellationToken);
+            return await response.Content.ReadFromJsonAsync<JotformResult<Dictionary<string, string>>>(_jsonSerializerOptions, cancellationToken)
+                .ConfigureAwait(false);
         }
         catch (JsonException)
         {

--- a/Jotform/Endpoints/Form/GetForm.cs
+++ b/Jotform/Endpoints/Form/GetForm.cs
@@ -2,6 +2,10 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Get basic information about a form.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
     public Task<JotformResult<Models.Shared.Form>?> GetFormAsync(string formId, CancellationToken cancellationToken = default) 
         => GetResultAsync<Models.Shared.Form>($"form/{formId}",
             cancellationToken);

--- a/Jotform/Endpoints/Form/GetFormFiles.cs
+++ b/Jotform/Endpoints/Form/GetFormFiles.cs
@@ -7,6 +7,7 @@ public partial class JotformClient
             cancellationToken);
 }
 
+#nullable disable
 public class FormFile
 {
     [JsonPropertyName("name")]

--- a/Jotform/Endpoints/Form/GetFormFiles.cs
+++ b/Jotform/Endpoints/Form/GetFormFiles.cs
@@ -2,6 +2,10 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Get a list of files uploaded on a form. Size and file type is also included.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
     public Task<JotformResult<FormFile[]>?> GetFormFilesAsync(string formId, CancellationToken cancellationToken = default) 
         => GetResultAsync<FormFile[]>($"form/{formId}/files",
             cancellationToken);

--- a/Jotform/Endpoints/Form/GetFormFiles.cs
+++ b/Jotform/Endpoints/Form/GetFormFiles.cs
@@ -11,30 +11,29 @@ public partial class JotformClient
             cancellationToken);
 }
 
-#nullable disable
 public class FormFile
 {
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     [JsonPropertyName("type")]
-    public string Type { get; set; }
+    public string Type { get; set; } = null!;
 
     [JsonPropertyName("size")]
-    public string Size { get; set; }
+    public string Size { get; set; } = null!;
 
     [JsonPropertyName("username")]
-    public string Username { get; set; }
+    public string Username { get; set; } = null!;
 
     [JsonPropertyName("form_id")]
-    public string FormId { get; set; }
+    public string FormId { get; set; } = null!;
 
     [JsonPropertyName("submission_id")]
-    public string SubmissionId { get; set; }
+    public string SubmissionId { get; set; } = null!;
 
     [JsonPropertyName("date")]
-    public string Date { get; set; }
+    public string Date { get; set; } = null!;
 
     [JsonPropertyName("url")]
-    public string Url { get; set; }
+    public string Url { get; set; } = null!;
 }

--- a/Jotform/Endpoints/Form/GetFormProperties.cs
+++ b/Jotform/Endpoints/Form/GetFormProperties.cs
@@ -7,6 +7,7 @@ public partial class JotformClient
             cancellationToken);
 }
 
+#nullable disable
 public class Coupon
     {
         [JsonPropertyName("apply")]

--- a/Jotform/Endpoints/Form/GetFormProperties.cs
+++ b/Jotform/Endpoints/Form/GetFormProperties.cs
@@ -2,6 +2,10 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Get a list of all properties (https://api.jotform.com/docs/properties/index.php) on a form.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
     public Task<JotformResult<FormProperties>?> GetFormPropertiesAsync(string formId, CancellationToken cancellationToken = default) 
         => GetResultAsync<FormProperties>($"form/{formId}/properties",
             cancellationToken);

--- a/Jotform/Endpoints/Form/GetFormProperties.cs
+++ b/Jotform/Endpoints/Form/GetFormProperties.cs
@@ -6,434 +6,432 @@ public partial class JotformClient
     /// Get a list of all properties (https://api.jotform.com/docs/properties/index.php) on a form.
     /// </summary>
     /// <param name="formId">Form ID.</param>
-    public Task<JotformResult<FormProperties>?> GetFormPropertiesAsync(string formId, CancellationToken cancellationToken = default) 
+    public Task<JotformResult<FormProperties>?> GetFormPropertiesAsync(string formId, CancellationToken cancellationToken = default)
         => GetResultAsync<FormProperties>($"form/{formId}/properties",
             cancellationToken);
 }
 
-#nullable disable
 public class Coupon
-    {
-        [JsonPropertyName("apply")]
-        public string Apply { get; set; }
+{
+    [JsonPropertyName("apply")]
+    public string Apply { get; set; } = null!;
 
-        [JsonPropertyName("code")]
-        public string Code { get; set; }
+    [JsonPropertyName("code")]
+    public string Code { get; set; } = null!;
 
-        [JsonPropertyName("gatewayType")]
-        public string GatewayType { get; set; }
+    [JsonPropertyName("gatewayType")]
+    public string GatewayType { get; set; } = null!;
 
-        [JsonPropertyName("id")]
-        public string Id { get; set; }
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = null!;
 
-        [JsonPropertyName("limit")]
-        public string Limit { get; set; }
+    [JsonPropertyName("limit")]
+    public string Limit { get; set; } = null!;
 
-        [JsonPropertyName("products")]
-        public string Products { get; set; }
+    [JsonPropertyName("products")]
+    public string Products { get; set; } = null!;
 
-        [JsonPropertyName("rate")]
-        public string Rate { get; set; }
+    [JsonPropertyName("rate")]
+    public string Rate { get; set; } = null!;
 
-        [JsonPropertyName("type")]
-        public string Type { get; set; }
-    }
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = null!;
+}
 
-    public class Email
-    {
-        [JsonPropertyName("body")]
-        public string Body { get; set; }
+public class Email
+{
+    [JsonPropertyName("body")]
+    public string Body { get; set; } = null!;
 
-        [JsonPropertyName("branding21Email")]
-        public bool Branding21Email { get; set; }
+    [JsonPropertyName("branding21Email")]
+    public bool Branding21Email { get; set; }
 
-        [JsonPropertyName("dirty")]
-        public string Dirty { get; set; }
+    [JsonPropertyName("dirty")]
+    public string Dirty { get; set; } = null!;
 
-        [JsonPropertyName("from")]
-        public string From { get; set; }
+    [JsonPropertyName("from")]
+    public string From { get; set; } = null!;
 
-        [JsonPropertyName("hideEmptyFields")]
-        public bool HideEmptyFields { get; set; }
+    [JsonPropertyName("hideEmptyFields")]
+    public bool HideEmptyFields { get; set; }
 
-        [JsonPropertyName("html")]
-        public bool Html { get; set; }
+    [JsonPropertyName("html")]
+    public bool Html { get; set; }
 
-        [JsonPropertyName("lastQuestionID")]
-        public string LastQuestionID { get; set; }
+    [JsonPropertyName("lastQuestionID")]
+    public string LastQuestionID { get; set; } = null!;
 
-        [JsonPropertyName("name")]
-        public string Name { get; set; }
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = null!;
 
-        [JsonPropertyName("pdfattachment")]
-        public bool Pdfattachment { get; set; }
+    [JsonPropertyName("pdfattachment")]
+    public bool Pdfattachment { get; set; }
 
-        [JsonPropertyName("pdfId")]
-        public string PdfId { get; set; }
+    [JsonPropertyName("pdfId")]
+    public string PdfId { get; set; } = null!;
 
-        [JsonPropertyName("replyTo")]
-        public string ReplyTo { get; set; }
+    [JsonPropertyName("replyTo")]
+    public string ReplyTo { get; set; } = null!;
 
-        [JsonPropertyName("sendOnEdit")]
-        public bool SendOnEdit { get; set; }
+    [JsonPropertyName("sendOnEdit")]
+    public bool SendOnEdit { get; set; }
 
-        [JsonPropertyName("sendOnSubmit")]
-        public bool SendOnSubmit { get; set; }
+    [JsonPropertyName("sendOnSubmit")]
+    public bool SendOnSubmit { get; set; }
 
-        [JsonPropertyName("subject")]
-        public string Subject { get; set; }
+    [JsonPropertyName("subject")]
+    public string Subject { get; set; } = null!;
 
-        [JsonPropertyName("to")]
-        public string To { get; set; }
+    [JsonPropertyName("to")]
+    public string To { get; set; } = null!;
 
-        [JsonPropertyName("type")]
-        public string Type { get; set; }
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = null!;
 
-        [JsonPropertyName("uniqueID")]
-        public string UniqueID { get; set; }
+    [JsonPropertyName("uniqueID")]
+    public string UniqueID { get; set; } = null!;
 
-        [JsonPropertyName("uploadAttachment")]
-        public string UploadAttachment { get; set; }
+    [JsonPropertyName("uploadAttachment")]
+    public string UploadAttachment { get; set; } = null!;
 
-        [JsonPropertyName("attachment")]
-        public string Attachment { get; set; }
+    [JsonPropertyName("attachment")]
+    public string Attachment { get; set; } = null!;
 
-        [JsonPropertyName("sendDate")]
-        public string SendDate { get; set; }
-    }
+    [JsonPropertyName("sendDate")]
+    public string SendDate { get; set; } = null!;
+}
 
-    public class PaymentListSetting
-    {
-        [JsonPropertyName("minTotalOrderAmount")]
-        public int MinTotalOrderAmount { get; set; }
+public class PaymentListSetting
+{
+    [JsonPropertyName("minTotalOrderAmount")]
+    public int MinTotalOrderAmount { get; set; }
 
-        [JsonPropertyName("productCategories")]
-        public string ProductCategories { get; set; }
+    [JsonPropertyName("productCategories")]
+    public string ProductCategories { get; set; } = null!;
 
-        [JsonPropertyName("productListLayout")]
-        public string ProductListLayout { get; set; }
+    [JsonPropertyName("productListLayout")]
+    public string ProductListLayout { get; set; } = null!;
 
-        [JsonPropertyName("showCategory")]
-        public bool ShowCategory { get; set; }
+    [JsonPropertyName("showCategory")]
+    public bool ShowCategory { get; set; }
 
-        [JsonPropertyName("showCategoryTitle")]
-        public bool ShowCategoryTitle { get; set; }
+    [JsonPropertyName("showCategoryTitle")]
+    public bool ShowCategoryTitle { get; set; }
 
-        [JsonPropertyName("showMinTotalOrderAmount")]
-        public bool ShowMinTotalOrderAmount { get; set; }
+    [JsonPropertyName("showMinTotalOrderAmount")]
+    public bool ShowMinTotalOrderAmount { get; set; }
 
-        [JsonPropertyName("showSearch")]
-        public bool ShowSearch { get; set; }
+    [JsonPropertyName("showSearch")]
+    public bool ShowSearch { get; set; }
 
-        [JsonPropertyName("showSorting")]
-        public bool ShowSorting { get; set; }
-    }
+    [JsonPropertyName("showSorting")]
+    public bool ShowSorting { get; set; }
+}
 public class Product
-    {
-        [JsonPropertyName("connectedCategories")]
-        public string ConnectedCategories { get; set; }
+{
+    [JsonPropertyName("connectedCategories")]
+    public string ConnectedCategories { get; set; } = null!;
 
-        [JsonPropertyName("connectedProducts")]
-        public string ConnectedProducts { get; set; }
+    [JsonPropertyName("connectedProducts")]
+    public string ConnectedProducts { get; set; } = null!;
 
-        [JsonPropertyName("description")]
-        public string Description { get; set; }
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = null!;
 
-        [JsonPropertyName("fitImageToCanvas")]
-        public bool FitImageToCanvas { get; set; }
+    [JsonPropertyName("fitImageToCanvas")]
+    public bool FitImageToCanvas { get; set; }
 
-        [JsonPropertyName("hasExpandedOption")]
-        public string HasExpandedOption { get; set; }
+    [JsonPropertyName("hasExpandedOption")]
+    public string HasExpandedOption { get; set; } = null!;
 
-        [JsonPropertyName("hasQuantity")]
-        public string HasQuantity { get; set; }
+    [JsonPropertyName("hasQuantity")]
+    public string HasQuantity { get; set; } = null!;
 
-        [JsonPropertyName("hasSpecialPricing")]
-        public string HasSpecialPricing { get; set; }
+    [JsonPropertyName("hasSpecialPricing")]
+    public string HasSpecialPricing { get; set; } = null!;
 
-        [JsonPropertyName("icon")]
-        public string Icon { get; set; }
+    [JsonPropertyName("icon")]
+    public string Icon { get; set; } = null!;
 
-        [JsonPropertyName("images")]
-        public string Images { get; set; }
+    [JsonPropertyName("images")]
+    public string Images { get; set; } = null!;
 
-        [JsonPropertyName("isLowStockAlertEnabled")]
-        public bool IsLowStockAlertEnabled { get; set; }
+    [JsonPropertyName("isLowStockAlertEnabled")]
+    public bool IsLowStockAlertEnabled { get; set; }
 
-        [JsonPropertyName("isStockControlEnabled")]
-        public bool IsStockControlEnabled { get; set; }
+    [JsonPropertyName("isStockControlEnabled")]
+    public bool IsStockControlEnabled { get; set; }
 
-        [JsonPropertyName("lowStockValue")]
-        public string LowStockValue { get; set; }
+    [JsonPropertyName("lowStockValue")]
+    public string LowStockValue { get; set; } = null!;
 
-        [JsonPropertyName("name")]
-        public string Name { get; set; }
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = null!;
 
-        [JsonPropertyName("options")]
-        public string Options { get; set; }
+    [JsonPropertyName("options")]
+    public string Options { get; set; } = null!;
 
-        [JsonPropertyName("pid")]
-        public string Pid { get; set; }
+    [JsonPropertyName("pid")]
+    public string Pid { get; set; } = null!;
 
-        [JsonPropertyName("price")]
-        public string Price { get; set; }
+    [JsonPropertyName("price")]
+    public string Price { get; set; } = null!;
 
-        [JsonPropertyName("required")]
-        public bool Required { get; set; }
+    [JsonPropertyName("required")]
+    public bool Required { get; set; }
 
-        [JsonPropertyName("selected")]
-        public bool Selected { get; set; }
-    }
+    [JsonPropertyName("selected")]
+    public bool Selected { get; set; }
+}
 
-    public class FormProperties
-    {
-        [JsonPropertyName("activeRedirect")]
-        public string ActiveRedirect { get; set; }
+public class FormProperties
+{
+    [JsonPropertyName("activeRedirect")]
+    public string ActiveRedirect { get; set; } = null!;
 
-        [JsonPropertyName("alignment")]
-        public string Alignment { get; set; }
+    [JsonPropertyName("alignment")]
+    public string Alignment { get; set; } = null!;
 
-        [JsonPropertyName("allowSubmissionEdit")]
-        public bool AllowSubmissionEdit { get; set; }
+    [JsonPropertyName("allowSubmissionEdit")]
+    public bool AllowSubmissionEdit { get; set; }
 
-        [JsonPropertyName("attachInvoice")]
-        public bool AttachInvoice { get; set; }
+    [JsonPropertyName("attachInvoice")]
+    public bool AttachInvoice { get; set; }
 
-        [JsonPropertyName("background")]
-        public string Background { get; set; }
+    [JsonPropertyName("background")]
+    public string Background { get; set; } = null!;
 
-        [JsonPropertyName("cardThemeID")]
-        public string CardThemeID { get; set; }
+    [JsonPropertyName("cardThemeID")]
+    public string CardThemeID { get; set; } = null!;
 
-        [JsonPropertyName("clearFieldOnHide")]
-        public string ClearFieldOnHide { get; set; }
+    [JsonPropertyName("clearFieldOnHide")]
+    public string ClearFieldOnHide { get; set; } = null!;
 
-        [JsonPropertyName("creationLanguage")]
-        public string CreationLanguage { get; set; }
+    [JsonPropertyName("creationLanguage")]
+    public string CreationLanguage { get; set; } = null!;
 
-        [JsonPropertyName("datetimeMigrationStatus")]
-        public string DatetimeMigrationStatus { get; set; }
+    [JsonPropertyName("datetimeMigrationStatus")]
+    public string DatetimeMigrationStatus { get; set; } = null!;
 
-        [JsonPropertyName("defaultAutoResponderEmailAssigned")]
-        public bool DefaultAutoResponderEmailAssigned { get; set; }
+    [JsonPropertyName("defaultAutoResponderEmailAssigned")]
+    public bool DefaultAutoResponderEmailAssigned { get; set; }
 
-        [JsonPropertyName("defaultEmailAssigned")]
-        public bool DefaultEmailAssigned { get; set; }
+    [JsonPropertyName("defaultEmailAssigned")]
+    public bool DefaultEmailAssigned { get; set; }
 
-        [JsonPropertyName("defaultTheme")]
-        public string DefaultTheme { get; set; }
+    [JsonPropertyName("defaultTheme")]
+    public string DefaultTheme { get; set; } = null!;
 
-        [JsonPropertyName("emailsToAttachInvoice")]
-        public string EmailsToAttachInvoice { get; set; }
+    [JsonPropertyName("emailsToAttachInvoice")]
+    public string EmailsToAttachInvoice { get; set; } = null!;
 
-        [JsonPropertyName("errorNavigation")]
-        public bool ErrorNavigation { get; set; }
+    [JsonPropertyName("errorNavigation")]
+    public bool ErrorNavigation { get; set; }
 
-        [JsonPropertyName("expireDate")]
-        public string ExpireDate { get; set; }
+    [JsonPropertyName("expireDate")]
+    public string ExpireDate { get; set; } = null!;
 
-        [JsonPropertyName("font")]
-        public string Font { get; set; }
+    [JsonPropertyName("font")]
+    public string Font { get; set; } = null!;
 
-        [JsonPropertyName("fontcolor")]
-        public string Fontcolor { get; set; }
+    [JsonPropertyName("fontcolor")]
+    public string Fontcolor { get; set; } = null!;
 
-        [JsonPropertyName("fontsize")]
-        public string Fontsize { get; set; }
+    [JsonPropertyName("fontsize")]
+    public string Fontsize { get; set; } = null!;
 
-        [JsonPropertyName("formStringsChanged")]
-        public bool FormStringsChanged { get; set; }
+    [JsonPropertyName("formStringsChanged")]
+    public bool FormStringsChanged { get; set; }
 
-        [JsonPropertyName("formType")]
-        public string FormType { get; set; }
+    [JsonPropertyName("formType")]
+    public string FormType { get; set; } = null!;
 
-        [JsonPropertyName("formWidth")]
-        public int FormWidth { get; set; }
+    [JsonPropertyName("formWidth")]
+    public int FormWidth { get; set; }
 
-        [JsonPropertyName("hash")]
-        public string Hash { get; set; }
+    [JsonPropertyName("hash")]
+    public string Hash { get; set; } = null!;
 
-        [JsonPropertyName("hideEmptySubmissionFields")]
-        public bool HideEmptySubmissionFields { get; set; }
+    [JsonPropertyName("hideEmptySubmissionFields")]
+    public bool HideEmptySubmissionFields { get; set; }
 
-        [JsonPropertyName("hideMailEmptyFields")]
-        public string HideMailEmptyFields { get; set; }
+    [JsonPropertyName("hideMailEmptyFields")]
+    public string HideMailEmptyFields { get; set; } = null!;
 
-        [JsonPropertyName("hideNonInputSubmissionFields")]
-        public bool HideNonInputSubmissionFields { get; set; }
+    [JsonPropertyName("hideNonInputSubmissionFields")]
+    public bool HideNonInputSubmissionFields { get; set; }
 
-        [JsonPropertyName("hideSubmissionHeader")]
-        public bool HideSubmissionHeader { get; set; }
+    [JsonPropertyName("hideSubmissionHeader")]
+    public bool HideSubmissionHeader { get; set; }
 
-        [JsonPropertyName("highlightLine")]
-        public string HighlightLine { get; set; }
+    [JsonPropertyName("highlightLine")]
+    public string HighlightLine { get; set; } = null!;
 
-        [JsonPropertyName("id")]
-        public string Id { get; set; }
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = null!;
 
-        [JsonPropertyName("injectCSS")]
-        public string InjectCSS { get; set; }
+    [JsonPropertyName("injectCSS")]
+    public string InjectCSS { get; set; } = null!;
 
-        [JsonPropertyName("invoiceEnabled")]
-        public bool InvoiceEnabled { get; set; }
+    [JsonPropertyName("invoiceEnabled")]
+    public bool InvoiceEnabled { get; set; }
 
-        [JsonPropertyName("isEncrypted")]
-        public bool IsEncrypted { get; set; }
+    [JsonPropertyName("isEncrypted")]
+    public bool IsEncrypted { get; set; }
 
-        [JsonPropertyName("isPaymentStoreInBasicFields")]
-        public bool IsPaymentStoreInBasicFields { get; set; }
+    [JsonPropertyName("isPaymentStoreInBasicFields")]
+    public bool IsPaymentStoreInBasicFields { get; set; }
 
-        [JsonPropertyName("labelWidth")]
-        public int LabelWidth { get; set; }
+    [JsonPropertyName("labelWidth")]
+    public int LabelWidth { get; set; }
 
-        [JsonPropertyName("lastQuestionID")]
-        public string LastQuestionID { get; set; }
+    [JsonPropertyName("lastQuestionID")]
+    public string LastQuestionID { get; set; } = null!;
 
-        [JsonPropertyName("limitSubmission")]
-        public string LimitSubmission { get; set; }
+    [JsonPropertyName("limitSubmission")]
+    public string LimitSubmission { get; set; } = null!;
 
-        [JsonPropertyName("lineSpacing")]
-        public int LineSpacing { get; set; }
+    [JsonPropertyName("lineSpacing")]
+    public int LineSpacing { get; set; }
 
-        [JsonPropertyName("messageOfLimitedForm")]
-        public string MessageOfLimitedForm { get; set; }
+    [JsonPropertyName("messageOfLimitedForm")]
+    public string MessageOfLimitedForm { get; set; } = null!;
 
-        [JsonPropertyName("mobileGoButton")]
-        public string MobileGoButton { get; set; }
+    [JsonPropertyName("mobileGoButton")]
+    public string MobileGoButton { get; set; } = null!;
 
-        [JsonPropertyName("newPaymentUIForNewCreatedForms")]
-        public bool NewPaymentUIForNewCreatedForms { get; set; }
+    [JsonPropertyName("newPaymentUIForNewCreatedForms")]
+    public bool NewPaymentUIForNewCreatedForms { get; set; }
 
-        [JsonPropertyName("optioncolor")]
-        public string Optioncolor { get; set; }
+    [JsonPropertyName("optioncolor")]
+    public string Optioncolor { get; set; } = null!;
 
-        [JsonPropertyName("pageColor")]
-        public string PageColor { get; set; }
+    [JsonPropertyName("pageColor")]
+    public string PageColor { get; set; } = null!;
 
-        [JsonPropertyName("pagetitle")]
-        public string Pagetitle { get; set; }
+    [JsonPropertyName("pagetitle")]
+    public string Pagetitle { get; set; } = null!;
 
-        [JsonPropertyName("pageTitleChanged")]
-        public bool PageTitleChanged { get; set; }
+    [JsonPropertyName("pageTitleChanged")]
+    public bool PageTitleChanged { get; set; }
 
-        [JsonPropertyName("paymentStringsChanged")]
-        public bool PaymentStringsChanged { get; set; }
+    [JsonPropertyName("paymentStringsChanged")]
+    public bool PaymentStringsChanged { get; set; }
 
-        [JsonPropertyName("preventCloningForm")]
-        public bool PreventCloningForm { get; set; }
+    [JsonPropertyName("preventCloningForm")]
+    public bool PreventCloningForm { get; set; }
 
-        [JsonPropertyName("responsive")]
-        public bool Responsive { get; set; }
+    [JsonPropertyName("responsive")]
+    public bool Responsive { get; set; }
 
-        [JsonPropertyName("sendpostdata")]
-        public bool Sendpostdata { get; set; }
+    [JsonPropertyName("sendpostdata")]
+    public bool Sendpostdata { get; set; }
 
-        [JsonPropertyName("showJotFormLogo")]
-        public bool ShowJotFormLogo { get; set; }
+    [JsonPropertyName("showJotFormLogo")]
+    public bool ShowJotFormLogo { get; set; }
 
-        [JsonPropertyName("showProgressBar")]
-        public string ShowProgressBar { get; set; }
+    [JsonPropertyName("showProgressBar")]
+    public string ShowProgressBar { get; set; } = null!;
 
-        [JsonPropertyName("styleJSON")]
-        public string StyleJSON { get; set; }
+    [JsonPropertyName("styleJSON")]
+    public string StyleJSON { get; set; } = null!;
 
-        [JsonPropertyName("styles")]
-        public string Styles { get; set; }
+    [JsonPropertyName("styles")]
+    public string Styles { get; set; } = null!;
 
-        [JsonPropertyName("submissionHeaders")]
-        public string SubmissionHeaders { get; set; }
+    [JsonPropertyName("submissionHeaders")]
+    public string SubmissionHeaders { get; set; } = null!;
 
-        [JsonPropertyName("submitError")]
-        public string SubmitError { get; set; }
+    [JsonPropertyName("submitError")]
+    public string SubmitError { get; set; } = null!;
 
-        [JsonPropertyName("thanktext")]
-        public string Thanktext { get; set; }
+    [JsonPropertyName("thanktext")]
+    public string Thanktext { get; set; } = null!;
 
-        [JsonPropertyName("thankYouDownloadPDF")]
-        public bool ThankYouDownloadPDF { get; set; }
+    [JsonPropertyName("thankYouDownloadPDF")]
+    public bool ThankYouDownloadPDF { get; set; }
 
-        [JsonPropertyName("thankYouEditSubmission")]
-        public bool ThankYouEditSubmission { get; set; }
+    [JsonPropertyName("thankYouEditSubmission")]
+    public bool ThankYouEditSubmission { get; set; }
 
-        [JsonPropertyName("thankYouFillAgain")]
-        public bool ThankYouFillAgain { get; set; }
+    [JsonPropertyName("thankYouFillAgain")]
+    public bool ThankYouFillAgain { get; set; }
 
-        [JsonPropertyName("thankYouIconSrc")]
-        public string ThankYouIconSrc { get; set; }
+    [JsonPropertyName("thankYouIconSrc")]
+    public string ThankYouIconSrc { get; set; } = null!;
 
-        [JsonPropertyName("thankYouImageSrc")]
-        public string ThankYouImageSrc { get; set; }
+    [JsonPropertyName("thankYouImageSrc")]
+    public string ThankYouImageSrc { get; set; } = null!;
 
-        [JsonPropertyName("thankYouPageLayout")]
-        public string ThankYouPageLayout { get; set; }
+    [JsonPropertyName("thankYouPageLayout")]
+    public string ThankYouPageLayout { get; set; } = null!;
 
-        [JsonPropertyName("thankYouSelectedPDFs")]
-        public bool ThankYouSelectedPDFs { get; set; }
+    [JsonPropertyName("thankYouSelectedPDFs")]
+    public bool ThankYouSelectedPDFs { get; set; }
 
-        [JsonPropertyName("themeID")]
-        public string ThemeID { get; set; }
+    [JsonPropertyName("themeID")]
+    public string ThemeID { get; set; } = null!;
 
-        [JsonPropertyName("unique")]
-        public string Unique { get; set; }
+    [JsonPropertyName("unique")]
+    public string Unique { get; set; } = null!;
 
-        [JsonPropertyName("uniqueField")]
-        public string UniqueField { get; set; }
+    [JsonPropertyName("uniqueField")]
+    public string UniqueField { get; set; } = null!;
 
-        [JsonPropertyName("usesNewPDF")]
-        public bool UsesNewPDF { get; set; }
+    [JsonPropertyName("usesNewPDF")]
+    public bool UsesNewPDF { get; set; }
 
-        [JsonPropertyName("v4")]
-        public bool V4 { get; set; }
+    [JsonPropertyName("v4")]
+    public bool V4 { get; set; }
 
-        [JsonPropertyName("coupons")]
-        public List<Coupon> Coupons { get; } = new List<Coupon>();
+    [JsonPropertyName("coupons")]
+    public List<Coupon> Coupons { get; } = new List<Coupon>();
 
-        [JsonPropertyName("emails")]
-        public List<Email> Emails { get; } = new List<Email>();
+    [JsonPropertyName("emails")]
+    public List<Email> Emails { get; } = new List<Email>();
 
-        [JsonPropertyName("paymentListSettings")]
-        public List<PaymentListSetting> PaymentListSettings { get; } = new List<PaymentListSetting>();
+    [JsonPropertyName("paymentListSettings")]
+    public List<PaymentListSetting> PaymentListSettings { get; } = new List<PaymentListSetting>();
 
-        [JsonPropertyName("paymentStrings")]
-        public Dictionary<int, string> PaymentStrings { get; } = new();
+    [JsonPropertyName("paymentStrings")]
+    public Dictionary<int, string> PaymentStrings { get; } = new();
 
-        [JsonPropertyName("products")]
-        public List<Product> Products { get; } = new List<Product>();
+    [JsonPropertyName("products")]
+    public List<Product> Products { get; } = new List<Product>();
 
-        [JsonPropertyName("submissionSettings")]
-        public List<object> SubmissionSettings { get; } = new List<object>();
+    [JsonPropertyName("submissionSettings")]
+    public List<object> SubmissionSettings { get; } = new List<object>();
 
-        [JsonPropertyName("integrations")]
-        public List<object> Integrations { get; } = new List<object>();
+    [JsonPropertyName("integrations")]
+    public List<object> Integrations { get; } = new List<object>();
 
-        [JsonPropertyName("slug")]
-        public string Slug { get; set; }
+    [JsonPropertyName("slug")]
+    public string Slug { get; set; } = null!;
 
-        [JsonPropertyName("owner")]
-        public string Owner { get; set; }
+    [JsonPropertyName("owner")]
+    public string Owner { get; set; } = null!;
 
-        [JsonPropertyName("title")]
-        public string Title { get; set; }
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = null!;
 
-        [JsonPropertyName("height")]
-        public string Height { get; set; }
+    [JsonPropertyName("height")]
+    public string Height { get; set; } = null!;
 
-        [JsonPropertyName("status")]
-        public string Status { get; set; }
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = null!;
 
-        [JsonPropertyName("type")]
-        public string Type { get; set; }
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = null!;
 
-        [JsonPropertyName("formOwnerAccountType")]
-        public string FormOwnerAccountType { get; set; }
+    [JsonPropertyName("formOwnerAccountType")]
+    public string FormOwnerAccountType { get; set; } = null!;
 
-        [JsonPropertyName("formOwnerName")]
-        public string FormOwnerName { get; set; }
+    [JsonPropertyName("formOwnerName")]
+    public string FormOwnerName { get; set; } = null!;
 
-        [JsonPropertyName("isHIPAA")]
-        public string IsHIPAA { get; set; }
+    [JsonPropertyName("isHIPAA")]
+    public string IsHIPAA { get; set; } = null!;
 
-        [JsonPropertyName("isEUForm")]
-        public string IsEUForm { get; set; }
-    }
-
+    [JsonPropertyName("isEUForm")]
+    public string IsEUForm { get; set; } = null!;
+}

--- a/Jotform/Endpoints/Form/GetFormProperty.cs
+++ b/Jotform/Endpoints/Form/GetFormProperty.cs
@@ -5,6 +5,12 @@ namespace Jotform;
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Get a specific property of the form.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
+    /// <param name="property">Property expression.</param>
+    /// <exception cref="InvalidOperationException">Throws if the specified property expression is not annotated with <see cref="JsonPropertyNameAttribute"/>.</exception>
     public async Task<JotformResult<FormProperties>?> GetFormPropertyAsync(string formId, Expression<Func<FormProperties, object>> property, CancellationToken cancellationToken = default)
     {
         MemberInfo GetCorrectPropertyMemberInfo<T>(Expression<Func<T, object>> expression)

--- a/Jotform/Endpoints/Form/GetFormQuestion.cs
+++ b/Jotform/Endpoints/Form/GetFormQuestion.cs
@@ -2,5 +2,10 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Get details about a question.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
+    /// <param name="questionId">Question ID.</param>
     public Task<JotformResult<Question>?> GetFormQuestionAsync(string formId, string questionId, CancellationToken cancellationToken = default) => GetResultAsync<Question>($"form/{formId}/question/{questionId}", cancellationToken);
 }

--- a/Jotform/Endpoints/Form/GetFormQuestions.cs
+++ b/Jotform/Endpoints/Form/GetFormQuestions.cs
@@ -2,6 +2,10 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Get a list of all questions on a form. Type describes in https://www.jotform.com/help/46-quick-overview-of-form-fields/. Order is the question order in the form. Text field is the question label.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
     public Task<JotformResult<Dictionary<string, Question>>?> GetFormQuestionsAsync(string formId, CancellationToken cancellationToken = default) 
         => GetResultAsync<Dictionary<string, Question>>(
             $"form/{formId}/questions", cancellationToken);

--- a/Jotform/Endpoints/Form/GetFormReports.cs
+++ b/Jotform/Endpoints/Form/GetFormReports.cs
@@ -2,6 +2,10 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Get all the reports of a specific form.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
     public Task<JotformResult<FormReport[]>?> GetFormReportsAsync(string formId, CancellationToken cancellationToken = default) 
         => GetResultAsync<FormReport[]>($"form/{formId}/reports",
             cancellationToken);

--- a/Jotform/Endpoints/Form/GetFormReports.cs
+++ b/Jotform/Endpoints/Form/GetFormReports.cs
@@ -7,6 +7,7 @@ public partial class JotformClient
             cancellationToken);
 }
 
+#nullable disable
 public class FormReport
 {
     [JsonPropertyName("id")]

--- a/Jotform/Endpoints/Form/GetFormReports.cs
+++ b/Jotform/Endpoints/Form/GetFormReports.cs
@@ -11,39 +11,38 @@ public partial class JotformClient
             cancellationToken);
 }
 
-#nullable disable
 public class FormReport
 {
     [JsonPropertyName("id")]
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
     [JsonPropertyName("form_id")]
-    public string FormId { get; set; }
+    public string FormId { get; set; } = null!;
 
     [JsonPropertyName("title")]
-    public string Title { get; set; }
+    public string Title { get; set; } = null!;
 
     [JsonPropertyName("created_at")]
-    public string CreatedAt { get; set; }
+    public string CreatedAt { get; set; } = null!;
 
     [JsonPropertyName("updated_at")]
-    public object UpdatedAt { get; set; }
+    public string? UpdatedAt { get; set; }
 
     [JsonPropertyName("url")]
-    public string Url { get; set; }
+    public string Url { get; set; } = null!;
 
     [JsonPropertyName("isProtected")]
     public bool? IsProtected { get; set; }
 
     [JsonPropertyName("fields")]
-    public string Fields { get; set; }
+    public string Fields { get; set; } = null!;
 
     [JsonPropertyName("list_type")]
-    public string ListType { get; set; }
+    public string ListType { get; set; } = null!;
 
     [JsonPropertyName("status")]
-    public string Status { get; set; }
+    public string Status { get; set; } = null!;
 
     [JsonPropertyName("settings")]
-    public string Settings { get; set; }
+    public string Settings { get; set; } = null!;
 }

--- a/Jotform/Endpoints/Form/GetFormSubmissions.cs
+++ b/Jotform/Endpoints/Form/GetFormSubmissions.cs
@@ -23,37 +23,35 @@ public partial class JotformClient
     }
 }
 
-#nullable disable
 public class FormSubmission
-    {
-        [JsonPropertyName("id")]
-        public string Id { get; set; }
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = null!;
 
-        [JsonPropertyName("form_id")]
-        public string FormId { get; set; }
+    [JsonPropertyName("form_id")]
+    public string FormId { get; set; } = null!;
 
-        [JsonPropertyName("ip")]
-        public string Ip { get; set; }
+    [JsonPropertyName("ip")]
+    public string Ip { get; set; } = null!;
 
-        [JsonPropertyName("created_at")]
-        public string CreatedAt { get; set; }
+    [JsonPropertyName("created_at")]
+    public string CreatedAt { get; set; } = null!;
 
-        [JsonPropertyName("status")]
-        public Status Status { get; set; }
+    [JsonPropertyName("status")]
+    public Status Status { get; set; }
 
-        [JsonPropertyName("new")]
-        public bool New { get; set; }
+    [JsonPropertyName("new")]
+    public bool New { get; set; }
 
-        [JsonPropertyName("flag")]
-        public bool Flag { get; set; }
+    [JsonPropertyName("flag")]
+    public bool Flag { get; set; }
 
-        [JsonPropertyName("notes")]
-        public string Notes { get; set; }
+    [JsonPropertyName("notes")]
+    public string Notes { get; set; } = null!;
 
-        [JsonPropertyName("updated_at")]
-        public string UpdatedAt { get; set; }
+    [JsonPropertyName("updated_at")]
+    public string UpdatedAt { get; set; } = null!;
 
-        [JsonPropertyName("answers")]
-        public Dictionary<string, Answer> Answers { get; set; }
-    }
-
+    [JsonPropertyName("answers")]
+    public Dictionary<string, Answer>? Answers { get; set; }
+}

--- a/Jotform/Endpoints/Form/GetFormSubmissions.cs
+++ b/Jotform/Endpoints/Form/GetFormSubmissions.cs
@@ -14,6 +14,8 @@ public partial class JotformClient
             cancellationToken);
     }
 }
+
+#nullable disable
 public class FormSubmission
     {
         [JsonPropertyName("id")]

--- a/Jotform/Endpoints/Form/GetFormSubmissions.cs
+++ b/Jotform/Endpoints/Form/GetFormSubmissions.cs
@@ -2,6 +2,14 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Get a list of form responses, answers array has the submitted data, Created_at is the date of the submission.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
+    /// <param name="offset">Start of each result set for form list. Useful for pagination. Default is 0. Example: 20</param>
+    /// <param name="limit">Number of results in each result set for form list. Default is 20. Maximum is 1000. Example: 30</param>
+    /// <param name="filter">Filters the query results to fetch a specific submissions range. Example: {"id:gt":"31974353596870" You can also use gt(greater than), lt(less than), ne(not equal to) commands to get more advanced filtering : Example: {"created_at:gt":"2013-01-01 00:00:00"} Example: {"workflowStatus:ne":"Approve"}</param>
+    /// <param name="orderBy">Order results by a form field name.</param>
     public Task<PagedJotformResult<FormSubmission>?> GetFormSubmissionsAsync(string formId, int? offset = null, int? limit = null, string? filter = null, string? orderBy = null, CancellationToken cancellationToken = default)
     {
         var url = new UriBuilder($"form/{formId}/submissions")

--- a/Jotform/Endpoints/Form/GetFormWebhooks.cs
+++ b/Jotform/Endpoints/Form/GetFormWebhooks.cs
@@ -4,6 +4,11 @@ namespace Jotform;
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Get a list of webhooks for a form.
+    /// </summary>
+    /// <remarks>Webhooks can be used to send form submission data as an instant notification.</remarks>
+    /// <param name="formId">Form ID.</param>
     public async Task<JotformResult<Dictionary<string, string>>?> GetFormWebhooksAsync(string formId, CancellationToken cancellationToken = default)
     {
         try

--- a/Jotform/Endpoints/Form/PostForm.cs
+++ b/Jotform/Endpoints/Form/PostForm.cs
@@ -17,7 +17,8 @@ public partial class JotformClient
         }
         
         var response = await _httpClient.PostAsync("form", 
-            formData.Build(), cancellationToken: cancellationToken);
+            formData.Build(), cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
     }

--- a/Jotform/Endpoints/Form/PostForm.cs
+++ b/Jotform/Endpoints/Form/PostForm.cs
@@ -2,11 +2,7 @@
 
 public partial class JotformClient
 {
-    /// <summary>
-    /// Sample response seems broken from the docs page, return void for now
-    /// </summary>
-    /// <param name="formDefinition"></param>
-    /// <param name="cancellationToken"></param>
+    // TODO: Sample response seems broken from the docs page, returning void for now.
     public async Task PostFormAsync(Dictionary<string, string> formDefinition, CancellationToken cancellationToken = default)
     {
         var formData = new FormDataBuilder();

--- a/Jotform/Endpoints/Form/PostFormClone.cs
+++ b/Jotform/Endpoints/Form/PostFormClone.cs
@@ -2,6 +2,10 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Clone a single form.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
     public async Task<JotformResult<Models.Shared.Form>?> PostFormCloneAsync(string formId, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.PostAsync($"form/{formId}/clone", content: null, cancellationToken)

--- a/Jotform/Endpoints/Form/PostFormClone.cs
+++ b/Jotform/Endpoints/Form/PostFormClone.cs
@@ -4,10 +4,12 @@ public partial class JotformClient
 {
     public async Task<JotformResult<Models.Shared.Form>?> PostFormCloneAsync(string formId, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.PostAsync($"form/{formId}/clone", content: null, cancellationToken);
+        var response = await _httpClient.PostAsync($"form/{formId}/clone", content: null, cancellationToken)
+            .ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<JotformResult<Models.Shared.Form>>(_jsonSerializerOptions, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<Models.Shared.Form>>(_jsonSerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/Jotform/Endpoints/Form/PostFormProperties.cs
+++ b/Jotform/Endpoints/Form/PostFormProperties.cs
@@ -2,6 +2,12 @@
 
 public partial class JotformClient
 {
+    // TODO: properties parameter should be documented properly or better to make it strongly type.
+    /// <summary>
+    /// Add or edit properties (https://api.jotform.com/docs/properties/index.php?field=form) of a specific form
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
+    /// <param name="properties"></param>
     public async Task<JotformResult<FormProperties>?> PostFormPropertiesAsync(string formId, Dictionary<string, string> properties, CancellationToken cancellationToken = default)
     {
         var formData = new FormDataBuilder();

--- a/Jotform/Endpoints/Form/PostFormProperties.cs
+++ b/Jotform/Endpoints/Form/PostFormProperties.cs
@@ -2,7 +2,7 @@
 
 public partial class JotformClient
 {
-    public async Task<Task<JotformResult<FormProperties>?>> PostFormPropertiesAsync(string formId, Dictionary<string, string> properties, CancellationToken cancellationToken = default)
+    public async Task<JotformResult<FormProperties>?> PostFormPropertiesAsync(string formId, Dictionary<string, string> properties, CancellationToken cancellationToken = default)
     {
         var formData = new FormDataBuilder();
         
@@ -11,10 +11,12 @@ public partial class JotformClient
             formData.Add(key, value);
         }
         
-        var response = await _httpClient.PostAsync($"form/{formId}/properties", formData.Build(), cancellationToken);
+        var response = await _httpClient.PostAsync($"form/{formId}/properties", formData.Build(), cancellationToken)
+            .ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
 
-        return response.Content.ReadFromJsonAsync<JotformResult<FormProperties>>(_jsonSerializerOptions, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<FormProperties>>(_jsonSerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/Jotform/Endpoints/Form/PostFormQuestion.cs
+++ b/Jotform/Endpoints/Form/PostFormQuestion.cs
@@ -2,6 +2,13 @@
 
 public partial class JotformClient
 {
+    // TODO: questionDefinition should be documented properly or better to make it strongly type.
+    /// <summary>
+    /// Add or edit a single question properties.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
+    /// <param name="questionId">Question ID.</param>
+    /// <param name="questionDefinition"></param>
     public async Task<JotformResult<Question>?> PostFormQuestionAsync(string formId, string questionId, Dictionary<string, string> questionDefinition, CancellationToken cancellationToken = default)
     {
         var formData = new FormDataBuilder();

--- a/Jotform/Endpoints/Form/PostFormQuestion.cs
+++ b/Jotform/Endpoints/Form/PostFormQuestion.cs
@@ -11,10 +11,11 @@ public partial class JotformClient
             formData.Add(key, value);
         }
         
-        var response = await _httpClient.PostAsync($"form/{formId}/question/{questionId}", formData.Build(), cancellationToken);
+        var response = await _httpClient.PostAsync($"form/{formId}/question/{questionId}", formData.Build(), cancellationToken).ConfigureAwait(false);
         
         response.EnsureSuccessStatusCode();
         
-        return await response.Content.ReadFromJsonAsync<JotformResult<Question>>(_jsonSerializerOptions, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<Question>>(_jsonSerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/Jotform/Endpoints/Form/PostFormQuestions.cs
+++ b/Jotform/Endpoints/Form/PostFormQuestions.cs
@@ -2,6 +2,12 @@
 
 public partial class JotformClient
 {
+    // TODO: questionDefinition should be documented properly or better to make it strongly type.
+    /// <summary>
+    /// Add new question to specified form. Form questions might have various properties (https://api.jotform.com/docs/properties/index.php). Examples: Is it required? Are there any validations such as 'numeric only'?.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
+    /// <param name="questionDefinition"></param>
     public async Task<JotformResult<Question>?> PostFormQuestionsAsync(string formId, Dictionary<string, string> questionDefinition, CancellationToken cancellationToken = default)
     {
         var formData = new FormDataBuilder();

--- a/Jotform/Endpoints/Form/PostFormQuestions.cs
+++ b/Jotform/Endpoints/Form/PostFormQuestions.cs
@@ -12,10 +12,12 @@ public partial class JotformClient
         }
 
         var response = await _httpClient.PostAsJsonAsync($"form/{formId}/questions", formData, _jsonSerializerOptions, 
-            cancellationToken: cancellationToken);
+            cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<JotformResult<Question>>(_jsonSerializerOptions, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<Question>>(_jsonSerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/Jotform/Endpoints/Form/PostFormReports.cs
+++ b/Jotform/Endpoints/Form/PostFormReports.cs
@@ -2,6 +2,13 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Create new report of a form with intended fields, type and title.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
+    /// <param name="reportTitle">Report title.</param>
+    /// <param name="listType">Report type</param>
+    /// <param name="fields">Report fields. e.g. User IP, submission date(dt) and question IDs.</param>
     public async Task<JotformResult<FormReport>?> PostFormReportsAsync(string formId, string reportTitle, ListType listType, string[]? fields, CancellationToken cancellationToken = default)
     {
         var formData = new FormDataBuilder();

--- a/Jotform/Endpoints/Form/PostFormReports.cs
+++ b/Jotform/Endpoints/Form/PostFormReports.cs
@@ -14,11 +14,13 @@ public partial class JotformClient
             formData.Add("fields", string.Join(",", fields));
         }
         
-        var response = await _httpClient.PostAsync($"form/{formId}/reports", formData.Build(), cancellationToken);
+        var response = await _httpClient.PostAsync($"form/{formId}/reports", formData.Build(), cancellationToken)
+            .ConfigureAwait(false);
         
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<JotformResult<FormReport>>(_jsonSerializerOptions, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<FormReport>>(_jsonSerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
     }
 }
 

--- a/Jotform/Endpoints/Form/PostFormSubmissions.cs
+++ b/Jotform/Endpoints/Form/PostFormSubmissions.cs
@@ -11,14 +11,17 @@ public partial class JotformClient
             formData.Add(key, value);
         }
         
-        var response = await _httpClient.PostAsync($"form/{formId}/submissions", formData.Build(), cancellationToken);
+        var response = await _httpClient.PostAsync($"form/{formId}/submissions", formData.Build(), cancellationToken)
+            .ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<JotformResult<PostFormSubmissionsResponse>>(_jsonSerializerOptions, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<PostFormSubmissionsResponse>>(_jsonSerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
     }
 }
 
+#nullable disable
 public class PostFormSubmissionsResponse
 {
     [JsonPropertyName("submissionID")]

--- a/Jotform/Endpoints/Form/PostFormSubmissions.cs
+++ b/Jotform/Endpoints/Form/PostFormSubmissions.cs
@@ -2,6 +2,12 @@
 
 public partial class JotformClient
 {
+    // TODO: reponses parameter should be documented properly or better to make it strongly type.
+    /// <summary>
+    /// Add a submission (submit data) to the form.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
+    /// <param name="responses"></param>
     public async Task<JotformResult<PostFormSubmissionsResponse>?> PostFormSubmissionsAsync(string formId, Dictionary<string, string> responses, CancellationToken cancellationToken = default)
     {
         var formData = new FormDataBuilder();

--- a/Jotform/Endpoints/Form/PostFormSubmissions.cs
+++ b/Jotform/Endpoints/Form/PostFormSubmissions.cs
@@ -27,12 +27,11 @@ public partial class JotformClient
     }
 }
 
-#nullable disable
 public class PostFormSubmissionsResponse
 {
     [JsonPropertyName("submissionID")]
-    public string SubmissionID { get; set; }
+    public string SubmissionID { get; set; } = null!;
 
     [JsonPropertyName("URL")]
-    public string URL { get; set; }
+    public string URL { get; set; } = null!;
 }

--- a/Jotform/Endpoints/Form/PostFormWebhook.cs
+++ b/Jotform/Endpoints/Form/PostFormWebhook.cs
@@ -15,13 +15,14 @@ public partial class JotformClient
         
         formData.Add("webhookURL", webhookUrl.ToString());
 
-        var response = await _httpClient.PostAsync($"form/{formId}/webhooks", formData.Build(), cancellationToken);
+        var response = await _httpClient.PostAsync($"form/{formId}/webhooks", formData.Build(), cancellationToken)
+            .ConfigureAwait(false);
         
         response.EnsureSuccessStatusCode();
 
         try
         {
-            return await response.Content.ReadFromJsonAsync<JotformResult<Dictionary<string, string>>>(_jsonSerializerOptions, cancellationToken);
+            return await response.Content.ReadFromJsonAsync<JotformResult<Dictionary<string, string>>>(_jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
         }
         catch (JsonException)
         {

--- a/Jotform/Endpoints/Form/PostFormWebhook.cs
+++ b/Jotform/Endpoints/Form/PostFormWebhook.cs
@@ -4,6 +4,12 @@ namespace Jotform;
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Add a new webhook.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
+    /// <param name="webhookUrl">Webhook URL is where form data will be posted when form is submitted. Example: http://my.web.tld/handle.php</param>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
     public async Task<JotformResult<Dictionary<string, string>>?> PostFormWebhookAsync(string formId, Uri webhookUrl, CancellationToken cancellationToken = default)
     {
         if (!webhookUrl.IsAbsoluteUri)

--- a/Jotform/Endpoints/Form/PutForm.cs
+++ b/Jotform/Endpoints/Form/PutForm.cs
@@ -5,7 +5,8 @@ public partial class JotformClient
     public async Task PutFormAsync(object formDefinition, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.PutAsJsonAsync("form", formDefinition, _jsonSerializerOptions, 
-            cancellationToken: cancellationToken);
+            cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
     }

--- a/Jotform/Endpoints/Form/PutForm.cs
+++ b/Jotform/Endpoints/Form/PutForm.cs
@@ -2,6 +2,7 @@
 
 public partial class JotformClient
 {
+    // TODO: Sample response seems broken from the docs page, returning void for now.
     public async Task PutFormAsync(object formDefinition, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.PutAsJsonAsync("form", formDefinition, _jsonSerializerOptions, 

--- a/Jotform/Endpoints/Form/PutFormProperties.cs
+++ b/Jotform/Endpoints/Form/PutFormProperties.cs
@@ -2,6 +2,12 @@
 
 public partial class JotformClient 
 {
+    // TODO: formProperties parameter should be documented properly or better to make it strongly type.
+    /// <summary>
+    /// Add or edit properties of a specific form
+    /// </summary>
+    /// <param name="formId">Form ID></param>
+    /// <param name="formProperties"></param>
     public async Task<JotformResult<FormProperties>?> PutFormPropertiesAsync(string formId, object formProperties, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.PutAsJsonAsync($"form/{formId}/properties", formProperties, _jsonSerializerOptions, 

--- a/Jotform/Endpoints/Form/PutFormProperties.cs
+++ b/Jotform/Endpoints/Form/PutFormProperties.cs
@@ -5,10 +5,11 @@ public partial class JotformClient
     public async Task<JotformResult<FormProperties>?> PutFormPropertiesAsync(string formId, object formProperties, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.PutAsJsonAsync($"form/{formId}/properties", formProperties, _jsonSerializerOptions, 
-            cancellationToken: cancellationToken);
+            cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
         
-        return await response.Content.ReadFromJsonAsync<JotformResult<FormProperties>>(_jsonSerializerOptions, cancellationToken: cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<FormProperties>>(_jsonSerializerOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/Jotform/Endpoints/Form/PutFormQuestions.cs
+++ b/Jotform/Endpoints/Form/PutFormQuestions.cs
@@ -2,6 +2,11 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Add new questions to specified form. Form questions might have various properties (https://api.jotform.com/docs/properties/index.php). Examples: Is it required? Are there any validations such as 'numeric only'?.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
+    /// <param name="questions">New question's properties (https://api.jotform.com/docs/properties/index.php).</param>
     public async Task<JotformResult<Dictionary<string, Question>>?> PutFormQuestionsAsync(string formId, object questions, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.PutAsJsonAsync($"form/{formId}/questions", questions, _jsonSerializerOptions, 

--- a/Jotform/Endpoints/Form/PutFormQuestions.cs
+++ b/Jotform/Endpoints/Form/PutFormQuestions.cs
@@ -5,10 +5,12 @@ public partial class JotformClient
     public async Task<JotformResult<Dictionary<string, Question>>?> PutFormQuestionsAsync(string formId, object questions, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.PutAsJsonAsync($"form/{formId}/questions", questions, _jsonSerializerOptions, 
-            cancellationToken: cancellationToken);
+            cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<JotformResult<Dictionary<string, Question>>>(_jsonSerializerOptions, cancellationToken: cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<Dictionary<string, Question>>>(_jsonSerializerOptions, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/Jotform/Endpoints/Form/PutFormSubmissions.cs
+++ b/Jotform/Endpoints/Form/PutFormSubmissions.cs
@@ -4,10 +4,10 @@ public partial class JotformClient
 {
     public async Task<JotformResult<PostFormSubmissionsResponse[]>?> PutFormSubmissionsAsync(string formId, object responses, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.PutAsJsonAsync($"form/{formId}/submissions", responses, _jsonSerializerOptions, cancellationToken);
+        var response = await _httpClient.PutAsJsonAsync($"form/{formId}/submissions", responses, _jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<JotformResult<PostFormSubmissionsResponse[]>>(_jsonSerializerOptions, cancellationToken: cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<PostFormSubmissionsResponse[]>>(_jsonSerializerOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/Jotform/Endpoints/Form/PutFormSubmissions.cs
+++ b/Jotform/Endpoints/Form/PutFormSubmissions.cs
@@ -2,6 +2,12 @@
 
 public partial class JotformClient 
 {
+    // TODO: reponses parameter should be documented properly or better to make it strongly type.
+    /// <summary>
+    /// Add submissions to the form.
+    /// </summary>
+    /// <param name="formId">Form ID.</param>
+    /// <param name="responses"></param>
     public async Task<JotformResult<PostFormSubmissionsResponse[]>?> PutFormSubmissionsAsync(string formId, object responses, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.PutAsJsonAsync($"form/{formId}/submissions", responses, _jsonSerializerOptions, cancellationToken).ConfigureAwait(false);

--- a/Jotform/Endpoints/Report/DeleteReport.cs
+++ b/Jotform/Endpoints/Report/DeleteReport.cs
@@ -4,10 +4,11 @@ public partial class JotformClient
 {
     public async Task<JotformResult<string>?> DeleteReportAsync(string reportId, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.DeleteAsync($"report/{reportId}", cancellationToken);
+        var response = await _httpClient.DeleteAsync($"report/{reportId}", cancellationToken).ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<JotformResult<string>>(_jsonSerializerOptions, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<string>>(_jsonSerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/Jotform/Endpoints/Report/DeleteReport.cs
+++ b/Jotform/Endpoints/Report/DeleteReport.cs
@@ -2,6 +2,10 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Delete an existing report.
+    /// </summary>
+    /// <param name="reportId">Report ID.</param>
     public async Task<JotformResult<string>?> DeleteReportAsync(string reportId, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.DeleteAsync($"report/{reportId}", cancellationToken).ConfigureAwait(false);

--- a/Jotform/Endpoints/Report/GetReport.cs
+++ b/Jotform/Endpoints/Report/GetReport.cs
@@ -2,6 +2,10 @@
 
 public partial class JotformClient 
 {
+    /// <summary>
+    /// Get more information about a data report.
+    /// </summary>
+    /// <param name="reportId">Report ID.</param>
     public Task<JotformResult<FormReport>?> GetReportAsync(string reportId, CancellationToken cancellationToken = default) 
         => GetResultAsync<FormReport>($"report/{reportId}",
             cancellationToken);

--- a/Jotform/Endpoints/Submission/DeleteSubmission.cs
+++ b/Jotform/Endpoints/Submission/DeleteSubmission.cs
@@ -2,7 +2,7 @@
 
 public partial class JotformClient
 {
-    public async Task<JotformResult<string>?> DeleteSubmissionAsync(string submissionId, CancellationToken cancellationToken = default) 
-        => await _httpClient.DeleteFromJsonAsync<JotformResult<string>>($"submission/{submissionId}", 
+    public Task<JotformResult<string>?> DeleteSubmissionAsync(string submissionId, CancellationToken cancellationToken = default) 
+        => _httpClient.DeleteFromJsonAsync<JotformResult<string>>($"submission/{submissionId}", 
             _jsonSerializerOptions, cancellationToken);
 }

--- a/Jotform/Endpoints/Submission/DeleteSubmission.cs
+++ b/Jotform/Endpoints/Submission/DeleteSubmission.cs
@@ -2,6 +2,10 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Delete a single submission.
+    /// </summary>
+    /// <param name="submissionId">Submission ID.</param>
     public Task<JotformResult<string>?> DeleteSubmissionAsync(string submissionId, CancellationToken cancellationToken = default) 
         => _httpClient.DeleteFromJsonAsync<JotformResult<string>>($"submission/{submissionId}", 
             _jsonSerializerOptions, cancellationToken);

--- a/Jotform/Endpoints/Submission/GetSubmission.cs
+++ b/Jotform/Endpoints/Submission/GetSubmission.cs
@@ -2,6 +2,10 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Get Submission Data.
+    /// </summary>
+    /// <param name="submissionId">Submission ID.</param>
     public Task<JotformResult<FormSubmission>?> GetSubmissionAsync(string submissionId, CancellationToken cancellationToken = default) 
         => GetResultAsync<FormSubmission>($"submission/{submissionId}",
             cancellationToken);

--- a/Jotform/Endpoints/Submission/PostSubmission.cs
+++ b/Jotform/Endpoints/Submission/PostSubmission.cs
@@ -2,6 +2,11 @@
 
 public partial class JotformClient 
 {
+    /// <summary>
+    /// Edit a single submission.
+    /// </summary>
+    /// <param name="submissionId">Submission ID.</param>
+    /// <param name="responses">Data entered in questions.</param>
     public async Task<JotformResult<PostFormSubmissionsResponse>?> PostSubmissionAsync(string submissionId, Dictionary<string, string> responses, CancellationToken cancellationToken = default)
     {
         var formData = new FormDataBuilder();

--- a/Jotform/Endpoints/Submission/PostSubmission.cs
+++ b/Jotform/Endpoints/Submission/PostSubmission.cs
@@ -11,10 +11,11 @@ public partial class JotformClient
             formData.Add(key, value);
         }
         
-        var response = await _httpClient.PostAsync($"submission/{submissionId}", formData.Build(), cancellationToken);
+        var response = await _httpClient.PostAsync($"submission/{submissionId}", formData.Build(), cancellationToken)
+            .ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<JotformResult<PostFormSubmissionsResponse>>(_jsonSerializerOptions, cancellationToken: cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<PostFormSubmissionsResponse>>(_jsonSerializerOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/Jotform/Endpoints/System/GetSystemPlan.cs
+++ b/Jotform/Endpoints/System/GetSystemPlan.cs
@@ -19,162 +19,162 @@ public enum SystemPlanType
     Platinum
 }
 
-#nullable disable
+
 public class AnnualPlans
-    {
-        [JsonPropertyName("monthly")]
-        public int? Monthly { get; set; }
+{
+    [JsonPropertyName("monthly")]
+    public int? Monthly { get; set; }
 
-        [JsonPropertyName("yearly")]
-        public int? Yearly { get; set; }
+    [JsonPropertyName("yearly")]
+    public int? Yearly { get; set; }
 
-        [JsonPropertyName("biyearly")]
-        public int? Biyearly { get; set; }
-    }
+    [JsonPropertyName("biyearly")]
+    public int? Biyearly { get; set; }
+}
 
-    public class Campaigns
-    {
-        [JsonPropertyName("annualPlans")]
-        public AnnualPlans AnnualPlans { get; set; }
-    }
+public class Campaigns
+{
+    [JsonPropertyName("annualPlans")]
+    public AnnualPlans? AnnualPlans { get; set; }
+}
 
-    public class Emails
-    {
-        [JsonPropertyName("reminderEmailBlocks")]
-        public int? ReminderEmailBlocks { get; set; }
-    }
+public class Emails
+{
+    [JsonPropertyName("reminderEmailBlocks")]
+    public int? ReminderEmailBlocks { get; set; }
+}
 
-    public class FastSpringURLs
-    {
-        [JsonPropertyName("monthly")]
-        public string Monthly { get; set; }
+public class FastSpringURLs
+{
+    [JsonPropertyName("monthly")]
+    public string Monthly { get; set; } = null!;
 
-        [JsonPropertyName("yearly")]
-        public string Yearly { get; set; }
+    [JsonPropertyName("yearly")]
+    public string Yearly { get; set; } = null!;
 
-        [JsonPropertyName("biyearly")]
-        public string Biyearly { get; set; }
-    }
+    [JsonPropertyName("biyearly")]
+    public string Biyearly { get; set; } = null!;
+}
 
-    public class Limits
-    {
-        [JsonPropertyName("submissions")]
-        public int? Submissions { get; set; }
+public class Limits
+{
+    [JsonPropertyName("submissions")]
+    public int? Submissions { get; set; }
 
-        [JsonPropertyName("overSubmissions")]
-        public int? OverSubmissions { get; set; }
+    [JsonPropertyName("overSubmissions")]
+    public int? OverSubmissions { get; set; }
 
-        [JsonPropertyName("sslSubmissions")]
-        public int? SslSubmissions { get; set; }
+    [JsonPropertyName("sslSubmissions")]
+    public int? SslSubmissions { get; set; }
 
-        [JsonPropertyName("payments")]
-        public int? Payments { get; set; }
+    [JsonPropertyName("payments")]
+    public int? Payments { get; set; }
 
-        [JsonPropertyName("uploads")]
-        public long? Uploads { get; set; }
+    [JsonPropertyName("uploads")]
+    public long? Uploads { get; set; }
 
-        [JsonPropertyName("tickets")]
-        public int? Tickets { get; set; }
+    [JsonPropertyName("tickets")]
+    public int? Tickets { get; set; }
 
-        [JsonPropertyName("subusers")]
-        public int? Subusers { get; set; }
+    [JsonPropertyName("subusers")]
+    public int? Subusers { get; set; }
 
-        [JsonPropertyName("api-daily-limit")]
-        public int? ApiDailyLimit { get; set; }
+    [JsonPropertyName("api-daily-limit")]
+    public int? ApiDailyLimit { get; set; }
 
-        [JsonPropertyName("views")]
-        public int? Views { get; set; }
+    [JsonPropertyName("views")]
+    public int? Views { get; set; }
 
-        [JsonPropertyName("formCount")]
-        public int? FormCount { get; set; }
+    [JsonPropertyName("formCount")]
+    public int? FormCount { get; set; }
 
-        [JsonPropertyName("hipaaCompliance")]
-        public bool? HipaaCompliance { get; set; }
+    [JsonPropertyName("hipaaCompliance")]
+    public bool? HipaaCompliance { get; set; }
 
-        [JsonPropertyName("emails")]
-        public Emails Emails { get; set; }
+    [JsonPropertyName("emails")]
+    public Emails? Emails { get; set; }
 
-        [JsonPropertyName("signedDocuments")]
-        public int? SignedDocuments { get; set; }
-    }
+    [JsonPropertyName("signedDocuments")]
+    public int? SignedDocuments { get; set; }
+}
 
-    public class NonProfit
-    {
-        [JsonPropertyName("monthly")]
-        public double? Monthly { get; set; }
+public class NonProfit
+{
+    [JsonPropertyName("monthly")]
+    public double? Monthly { get; set; }
 
-        [JsonPropertyName("yearly")]
-        public int? Yearly { get; set; }
+    [JsonPropertyName("yearly")]
+    public int? Yearly { get; set; }
 
-        [JsonPropertyName("biyearly")]
-        public int? Biyearly { get; set; }
-    }
+    [JsonPropertyName("biyearly")]
+    public int? Biyearly { get; set; }
+}
 
-    public class OnSale
-    {
-        [JsonPropertyName("prices")]
-        public Prices Prices { get; set; }
+public class OnSale
+{
+    [JsonPropertyName("prices")]
+    public Prices? Prices { get; set; }
 
-        [JsonPropertyName("plimusIDs")]
-        public PlimusIDs PlimusIDs { get; set; }
+    [JsonPropertyName("plimusIDs")]
+    public PlimusIDs? PlimusIDs { get; set; }
 
-        [JsonPropertyName("nonProfit")]
-        public NonProfit NonProfit { get; set; }
+    [JsonPropertyName("nonProfit")]
+    public NonProfit? NonProfit { get; set; }
 
-        [JsonPropertyName("campaigns")]
-        public Campaigns Campaigns { get; set; }
-    }
+    [JsonPropertyName("campaigns")]
+    public Campaigns? Campaigns { get; set; }
+}
 
-    public class PlimusIDs
-    {
-        [JsonPropertyName("monthly")]
-        public int? Monthly { get; set; }
+public class PlimusIDs
+{
+    [JsonPropertyName("monthly")]
+    public int? Monthly { get; set; }
 
-        [JsonPropertyName("yearly")]
-        public int? Yearly { get; set; }
+    [JsonPropertyName("yearly")]
+    public int? Yearly { get; set; }
 
-        [JsonPropertyName("biyearly")]
-        public int? Biyearly { get; set; }
+    [JsonPropertyName("biyearly")]
+    public int? Biyearly { get; set; }
 
-        [JsonPropertyName("biyearly-single")]
-        public int? BiyearlySingle { get; set; }
-    }
+    [JsonPropertyName("biyearly-single")]
+    public int? BiyearlySingle { get; set; }
+}
 
-    public class Prices
-    {
-        [JsonPropertyName("monthly")]
-        public int? Monthly { get; set; }
+public class Prices
+{
+    [JsonPropertyName("monthly")]
+    public int? Monthly { get; set; }
 
-        [JsonPropertyName("yearly")]
-        public int? Yearly { get; set; }
+    [JsonPropertyName("yearly")]
+    public int? Yearly { get; set; }
 
-        [JsonPropertyName("biyearly")]
-        public int? Biyearly { get; set; }
-    }
+    [JsonPropertyName("biyearly")]
+    public int? Biyearly { get; set; }
+}
 
-    public class SystemPlan
-    {
-        [JsonPropertyName("name")]
-        public string Name { get; set; }
+public class SystemPlan
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = null!;
 
-        [JsonPropertyName("currency")]
-        public string Currency { get; set; }
+    [JsonPropertyName("currency")]
+    public string Currency { get; set; } = null!;
 
-        [JsonPropertyName("limits")]
-        public Limits Limits { get; set; }
+    [JsonPropertyName("limits")]
+    public Limits Limits { get; set; } = null!;
 
-        [JsonPropertyName("prices")]
-        public Prices Prices { get; set; }
+    [JsonPropertyName("prices")]
+    public Prices Prices { get; set; } = null!;
 
-        [JsonPropertyName("fastSpringURLs")]
-        public FastSpringURLs FastSpringURLs { get; set; }
+    [JsonPropertyName("fastSpringURLs")]
+    public FastSpringURLs? FastSpringURLs { get; set; }
 
-        [JsonPropertyName("onSale")]
-        public OnSale OnSale { get; set; }
+    [JsonPropertyName("onSale")]
+    public OnSale? OnSale { get; set; }
 
-        [JsonPropertyName("planType")]
-        public string PlanType { get; set; }
+    [JsonPropertyName("planType")]
+    public string PlanType { get; set; } = null!;
 
-        [JsonPropertyName("currentPlanType")]
-        public string CurrentPlanType { get; set; }
-    }
+    [JsonPropertyName("currentPlanType")]
+    public string CurrentPlanType { get; set; } = null!;
+}

--- a/Jotform/Endpoints/System/GetSystemPlan.cs
+++ b/Jotform/Endpoints/System/GetSystemPlan.cs
@@ -2,6 +2,9 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Get limit and prices of a plan.
+    /// </summary>
     public Task<JotformResult<SystemPlan>?> GetSystemPlanAsync(SystemPlanType plan, CancellationToken cancellationToken = default)
         => GetResultAsync<SystemPlan>($"system/plan/{plan.ToString()
             .ToUpper()}", cancellationToken);

--- a/Jotform/Endpoints/System/GetSystemPlan.cs
+++ b/Jotform/Endpoints/System/GetSystemPlan.cs
@@ -16,6 +16,7 @@ public enum SystemPlanType
     Platinum
 }
 
+#nullable disable
 public class AnnualPlans
     {
         [JsonPropertyName("monthly")]

--- a/Jotform/Endpoints/User/GetSubUsers.cs
+++ b/Jotform/Endpoints/User/GetSubUsers.cs
@@ -2,6 +2,10 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Get Sub-User Account List.
+    /// Get a list of sub users for this accounts and list of forms and form folders with access privileges.
+    /// </summary>
     public Task<JotformResult<GetSubUsersResponse[]>?> GetSubUsersAsync(CancellationToken cancellationToken = default)
         => GetResultAsync<GetSubUsersResponse[]>("user/subusers",
             cancellationToken);

--- a/Jotform/Endpoints/User/GetSubUsers.cs
+++ b/Jotform/Endpoints/User/GetSubUsers.cs
@@ -14,6 +14,7 @@ public enum PermissionType
     All
 }
 
+#nullable disable
 public class Permission
 {
     /// <summary>

--- a/Jotform/Endpoints/User/GetSubUsers.cs
+++ b/Jotform/Endpoints/User/GetSubUsers.cs
@@ -18,7 +18,6 @@ public enum PermissionType
     All
 }
 
-#nullable disable
 public class Permission
 {
     /// <summary>
@@ -31,16 +30,16 @@ public class Permission
     /// resource_id is form ID or folder ID, depending on type.
     /// </summary>
     [JsonPropertyName("resource_id")]
-    public string ResourceId { get; set; }
+    public string ResourceId { get; set; } = null!;
 
     /// <summary>
     /// access_type is full or readOnly. readOnly means form cannot be changed by the sub-user. Only submissions can be viewed.
     /// </summary>
     [JsonPropertyName("access_type")]
-    public string AccessType { get; set; }
+    public string AccessType { get; set; } = null!;
 
     [JsonPropertyName("title")]
-    public string Title { get; set; }
+    public string Title { get; set; } = null!;
 }
 
 public class GetSubUsersResponse
@@ -49,7 +48,7 @@ public class GetSubUsersResponse
     /// owner the parent account that created this sub-user.
     /// </summary>
     [JsonPropertyName("owner")]
-    public string Owner { get; set; }
+    public string Owner { get; set; } = null!;
 
     /// <summary>
     /// status can be LIVE, DELETED or PENDING. If the user has not accepted the invitation sub-user is in PENDING status.
@@ -58,18 +57,17 @@ public class GetSubUsersResponse
     public Status Status { get; set; }
 
     [JsonPropertyName("email")]
-    public string Email { get; set; }
+    public string Email { get; set; } = null!;
 
     [JsonPropertyName("username")]
-    public string Username { get; set; }
+    public string Username { get; set; } = null!;
 
     /// <summary>
     /// created_at: YYYY-MM-DD HH:MM:SS
     /// </summary>
     [JsonPropertyName("created_at")]
-    public string CreatedAt { get; set; }
+    public string CreatedAt { get; set; } = null!;
 
     [JsonPropertyName("permissions")]
     public List<Permission> Permissions { get; } = new();
 }
-

--- a/Jotform/Endpoints/User/GetUser.cs
+++ b/Jotform/Endpoints/User/GetUser.cs
@@ -11,32 +11,31 @@ public partial class JotformClient
         => GetResultAsync<GetUserResponse>("user", cancellationToken);
 }
 
-#nullable disable
 public class GetUserResponse
 {
     [JsonPropertyName("username")]
-    public string Username { get; set; }
+    public string Username { get; set; } = null!;
 
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     [JsonPropertyName("email")]
-    public string Email { get; set; }
+    public string Email { get; set; } = null!;
 
     [JsonPropertyName("website")]
-    public string Website { get; set; }
+    public string Website { get; set; } = null!;
 
     /// <summary>
     /// time_zone is in IANA format.
     /// </summary>
     [JsonPropertyName("time_zone")]
-    public string TimeZone { get; set; }
+    public string TimeZone { get; set; } = null!;
 
     /// <summary>
     /// account_type list can be seen in Pricing page.
     /// </summary>
     [JsonPropertyName("account_type")]
-    public string AccountType { get; set; }
+    public string AccountType { get; set; } = null!;
 
     [JsonPropertyName("status")]
     public Status Status { get; set; }
@@ -45,37 +44,37 @@ public class GetUserResponse
     /// created_at: YYYY-MM-DD HH:MM:SS
     /// </summary>
     [JsonPropertyName("created_at")]
-    public string CreatedAt { get; set; }
+    public string CreatedAt { get; set; } = null!;
 
     /// <summary>
     /// updated_at: YYYY-MM-DD HH:MM:SS
     /// </summary>
     [JsonPropertyName("updated_at")]
-    public string UpdatedAt { get; set; }
+    public string UpdatedAt { get; set; } = null!;
 
     [JsonPropertyName("is_verified")]
     public bool IsVerified { get; set; }
 
     [JsonPropertyName("usage")]
-    public string Usage { get; set; }
+    public string Usage { get; set; } = null!;
 
     [JsonPropertyName("industry")]
-    public string Industry { get; set; }
+    public string Industry { get; set; } = null!;
 
     [JsonPropertyName("securityAnswer")]
-    public string SecurityAnswer { get; set; }
+    public string SecurityAnswer { get; set; } = null!;
 
     [JsonPropertyName("company")]
-    public string Company { get; set; }
+    public string Company { get; set; } = null!;
 
     [JsonPropertyName("securityQuestion")]
-    public string SecurityQuestion { get; set; }
+    public string SecurityQuestion { get; set; } = null!;
 
     /// <summary>
     /// JSON serialized array of webhooks (string[])
     /// </summary>
     [JsonPropertyName("webhooks")]
-    public string Webhooks { get; set; }
+    public string Webhooks { get; set; } = null!;
 
     [JsonPropertyName("doNotClone")]
     public bool DoNotClone { get; set; }
@@ -84,11 +83,11 @@ public class GetUserResponse
     /// JSON serialized objection with a root node, and its tree structure
     /// </summary>
     [JsonPropertyName("folderLayout")]
-    public string FolderLayout { get; set; }
+    public string FolderLayout { get; set; } = null!;
 
     [JsonPropertyName("language")]
-    public string Language { get; set; }
+    public string Language { get; set; } = null!;
 
     [JsonPropertyName("avatarUrl")]
-    public string AvatarUrl { get; set; }
+    public string AvatarUrl { get; set; } = null!;
 }

--- a/Jotform/Endpoints/User/GetUser.cs
+++ b/Jotform/Endpoints/User/GetUser.cs
@@ -1,5 +1,4 @@
-﻿
-namespace Jotform;
+﻿namespace Jotform;
 
 public partial class JotformClient
 {
@@ -12,6 +11,7 @@ public partial class JotformClient
         => GetResultAsync<GetUserResponse>("user", cancellationToken);
 }
 
+#nullable disable
 public class GetUserResponse
 {
     [JsonPropertyName("username")]

--- a/Jotform/Endpoints/User/GetUserFolders.cs
+++ b/Jotform/Endpoints/User/GetUserFolders.cs
@@ -7,7 +7,8 @@ public partial class JotformClient
             cancellationToken);
 }
 
-    public class Form
+#nullable disable
+public class Form
     {
         [JsonPropertyName("id")]
         public string Id { get; set; }

--- a/Jotform/Endpoints/User/GetUserFolders.cs
+++ b/Jotform/Endpoints/User/GetUserFolders.cs
@@ -2,6 +2,10 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Get User Folders.
+    /// Get a list of form folders for this account.Returns name of the folder and owner of the folder for shared folders.
+    /// </summary>
     public Task<JotformResult<GetUserFoldersResponse>?> GetUserFoldersAsync(CancellationToken cancellationToken = default)
         => GetResultAsync<GetUserFoldersResponse>("user/folders",
             cancellationToken);

--- a/Jotform/Endpoints/User/GetUserFolders.cs
+++ b/Jotform/Endpoints/User/GetUserFolders.cs
@@ -11,17 +11,16 @@ public partial class JotformClient
             cancellationToken);
 }
 
-#nullable disable
 public class Form
     {
         [JsonPropertyName("id")]
-        public string Id { get; set; }
+        public string Id { get; set; } = null!;
 
         [JsonPropertyName("username")]
-        public string Username { get; set; }
+        public string Username { get; set; } = null!;
 
         [JsonPropertyName("title")]
-        public string Title { get; set; }
+        public string Title { get; set; } = null!;
 
         [JsonPropertyName("height")]
         public int Height { get; set; }
@@ -30,10 +29,10 @@ public class Form
         public Status Status { get; set; }
 
         [JsonPropertyName("created_at")]
-        public string CreatedAt { get; set; }
+        public string CreatedAt { get; set; } = null!;
 
         [JsonPropertyName("updated_at")]
-        public string UpdatedAt { get; set; }
+        public string UpdatedAt { get; set; } = null!;
 
         [JsonPropertyName("new")]
         public bool New { get; set; }
@@ -42,13 +41,13 @@ public class Form
         public int Count { get; set; }
 
         [JsonPropertyName("source")]
-        public string Source { get; set; }
+        public string Source { get; set; } = null!;
 
         [JsonPropertyName("slug")]
-        public string Slug { get; set; }
+        public string Slug { get; set; } = null!;
 
         [JsonPropertyName("url")]
-        public string Url { get; set; }
+        public string Url { get; set; } = null!;
     }
 
     public class GetUserFoldersResponse
@@ -57,34 +56,34 @@ public class Form
         /// id is folder ID.
         /// </summary>
         [JsonPropertyName("id")]
-        public string Id { get; set; }
+        public string Id { get; set; } = null!;
 
         /// <summary>
         /// path is list of folders above this folder separated with comma.
         /// </summary>
         [JsonPropertyName("path")]
-        public string Path { get; set; }
+        public string Path { get; set; } = null!;
 
         [JsonPropertyName("owner")]
-        public string Owner { get; set; }
+        public string Owner { get; set; } = null!;
 
         [JsonPropertyName("name")]
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         /// <summary>
         /// parent is the next folder above. If this folder is a root folder parent returns itself.
         /// </summary>
         [JsonPropertyName("parent")]
-        public string Parent { get; set; }
+        public string Parent { get; set; } = null!;
 
         [JsonPropertyName("color")]
-        public string Color { get; set; }
+        public string Color { get; set; } = null!;
 
         /// <summary>
         /// forms lists all forms under this folder.
         /// </summary>
         [JsonPropertyName("forms")]
-        public Dictionary<string, Form> Forms { get; set; }
+        public Dictionary<string, Form>? Forms { get; set; }
 
         /// <summary>
         /// subfolders lists all folders under this folder.
@@ -96,22 +95,22 @@ public class Form
 public class Folder
     {
         [JsonPropertyName("id")]
-        public string Id { get; set; }
+        public string Id { get; set; } = null!;
 
         [JsonPropertyName("path")]
-        public string Path { get; set; }
+        public string Path { get; set; } = null!;
 
         [JsonPropertyName("owner")]
-        public string Owner { get; set; }
+        public string Owner { get; set; } = null!;
 
         [JsonPropertyName("name")]
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         [JsonPropertyName("parent")]
-        public string Parent { get; set; }
+        public string Parent { get; set; } = null!;
 
         [JsonPropertyName("color")]
-        public string Color { get; set; }
+        public string Color { get; set; } = null!;
 
         [JsonPropertyName("forms")]
         public List<Form> Forms { get; } = new();

--- a/Jotform/Endpoints/User/GetUserHistory.cs
+++ b/Jotform/Endpoints/User/GetUserHistory.cs
@@ -2,6 +2,14 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Get History.
+    /// User activity log about things like forms created/modified/deleted, account logins and other operations.
+    /// </summary>
+    /// <param name="action">Filter results by activity performed. Default is 'all'.</param>
+    /// <param name="date">Limit results by a date range. If you'd like to limit results by specific dates you can use startDate and endDate fields instead. Example: lastWeek</param>
+    /// <param name="startDate">Limit results to only after a specific date. Format: MM/DD/YYYY. Example: 01/31/2013</param>
+    /// <param name="endDate">Limit results to only before a specific date. Format: MM/DD/YYYY. Example: 12/31/2013</param>
     public Task<JotformResult<HistoryLog[]>?> GetUserHistoryAsync(HistoryAction? action = null, HistoryDate? date = null, string? startDate = null, string? endDate = null,
         CancellationToken cancellationToken = default)
     {

--- a/Jotform/Endpoints/User/GetUserHistory.cs
+++ b/Jotform/Endpoints/User/GetUserHistory.cs
@@ -64,26 +64,25 @@ public enum SortBy
     Descending
 }
 
-#nullable disable
 public class HistoryLog
 {
     [JsonPropertyName("type")]
-    public string Type { get; set; }
+    public string Type { get; set; } = null!;
 
     [JsonPropertyName("formID")]
-    public string FormID { get; set; }
+    public string FormID { get; set; } = null!;
 
     [JsonPropertyName("username")]
-    public string Username { get; set; }
+    public string Username { get; set; } = null!;
 
     [JsonPropertyName("formTitle")]
-    public string FormTitle { get; set; }
+    public string FormTitle { get; set; } = null!;
 
     [JsonPropertyName("formStatus")]
-    public string FormStatus { get; set; }
+    public string FormStatus { get; set; } = null!;
 
     [JsonPropertyName("ip")]
-    public string Ip { get; set; }
+    public string Ip { get; set; } = null!;
 
     /// <summary>
     /// timestamp is number of seconds since Jan 1st, 1970.
@@ -91,4 +90,3 @@ public class HistoryLog
     [JsonPropertyName("timestamp")]
     public int Timestamp { get; set; }
 }
-

--- a/Jotform/Endpoints/User/GetUserHistory.cs
+++ b/Jotform/Endpoints/User/GetUserHistory.cs
@@ -56,6 +56,7 @@ public enum SortBy
     Descending
 }
 
+#nullable disable
 public class HistoryLog
 {
     [JsonPropertyName("type")]

--- a/Jotform/Endpoints/User/GetUserLogout.cs
+++ b/Jotform/Endpoints/User/GetUserLogout.cs
@@ -2,6 +2,11 @@
 
 public partial class JotformClient
 {
+    // TODO: Needs to be implemented or deleted.
+    /// <summary>
+    /// Not implemented yet, just throws exception.
+    /// </summary>
+    /// <exception cref="NotSupportedException"></exception>
     public Task GetUserLogoutAsync(CancellationToken cancellationToken = default) 
         => throw new NotSupportedException();
 }

--- a/Jotform/Endpoints/User/GetUserReports.cs
+++ b/Jotform/Endpoints/User/GetUserReports.cs
@@ -8,6 +8,7 @@ public partial class JotformClient
             cancellationToken);
 }
 
+#nullable disable
 public class GetUserReportsResponse
 {
     /// <summary>

--- a/Jotform/Endpoints/User/GetUserReports.cs
+++ b/Jotform/Endpoints/User/GetUserReports.cs
@@ -2,7 +2,10 @@
 
 public partial class JotformClient
 {
-    // TODO: Returns pagination info, but does not take them as parameters
+    /// <summary>
+    /// Get User Reports.
+    /// List of URLS for reports in this account.Includes reports for all of the forms.ie.Excel, CSV, printable charts, embeddable HTML tables.
+    /// </summary>
     public Task<JotformResult<GetUserReportsResponse[]>?> GetUserReportsAsync(CancellationToken cancellationToken = default)
         => GetResultAsync<GetUserReportsResponse[]>("user/reports",
             cancellationToken);

--- a/Jotform/Endpoints/User/GetUserReports.cs
+++ b/Jotform/Endpoints/User/GetUserReports.cs
@@ -11,44 +11,43 @@ public partial class JotformClient
             cancellationToken);
 }
 
-#nullable disable
 public class GetUserReportsResponse
 {
     /// <summary>
     /// id is report ID.
     /// </summary>
     [JsonPropertyName("id")]
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
     [JsonPropertyName("form_id")]
-    public string FormId { get; set; }
+    public string FormId { get; set; } = null!;
 
     [JsonPropertyName("title")]
-    public string Title { get; set; }
+    public string Title { get; set; } = null!;
 
     /// <summary>
     /// created_at, updated_at: YYYY-MM-DD HH:MM:SS
     /// </summary>
     [JsonPropertyName("created_at")]
-    public string CreatedAt { get; set; }
+    public string CreatedAt { get; set; } = null!;
 
     /// <summary>
     /// created_at, updated_at: YYYY-MM-DD HH:MM:SS
     /// </summary>
     [JsonPropertyName("updated_at")]
-    public string UpdatedAt { get; set; }
+    public string UpdatedAt { get; set; } = null!;
 
     /// <summary>
     /// fields is a comma separated list of all fields.
     /// </summary>
     [JsonPropertyName("fields")]
-    public string Fields { get; set; }
+    public string Fields { get; set; } = null!;
 
     /// <summary>
     /// list_type can be excel, csv, grid, table, calendar, rss or visual.
     /// </summary>
     [JsonPropertyName("list_type")]
-    public string ListType { get; set; }
+    public string ListType { get; set; } = null!;
 
     /// <summary>
     /// status can be ENABLED or DELETED
@@ -57,7 +56,7 @@ public class GetUserReportsResponse
     public Status Status { get; set; }
 
     [JsonPropertyName("url")]
-    public string Url { get; set; }
+    public string Url { get; set; } = null!;
 
     /// <summary>
     /// isProtected is true if password protected

--- a/Jotform/Endpoints/User/GetUserSettings.cs
+++ b/Jotform/Endpoints/User/GetUserSettings.cs
@@ -2,6 +2,10 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Get User Settings.
+    /// Get user's time zone and language.
+    /// </summary>
     public Task<JotformResult<UserSettings>?> GetUserSettingsAsync(CancellationToken cancellationToken = default)
         => GetResultAsync<UserSettings>("user/settings",
             cancellationToken);

--- a/Jotform/Endpoints/User/GetUserSubmissions.cs
+++ b/Jotform/Endpoints/User/GetUserSubmissions.cs
@@ -19,6 +19,7 @@ public partial class JotformClient
     }
 }
 
+#nullable disable
 public class Answer
 {
     /// <summary>
@@ -41,7 +42,7 @@ public class Answer
     public object Response { get; set; }
     
     [JsonPropertyName("prettyFormat")]
-    public string? PrettyFormat { get; set; }
+    public string PrettyFormat { get; set; }
 }
 
 public class GetUserSubmissionsResponse

--- a/Jotform/Endpoints/User/GetUserSubmissions.cs
+++ b/Jotform/Endpoints/User/GetUserSubmissions.cs
@@ -19,30 +19,29 @@ public partial class JotformClient
     }
 }
 
-#nullable disable
 public class Answer
 {
     /// <summary>
     /// text is the question label on the form
     /// </summary>
     [JsonPropertyName("text")]
-    public string Text { get; set; }
+    public string Text { get; set; } = null!;
 
     /// <summary>
     /// type is the question type such as textbox or dropdown
     /// Most commonly used types are control_textbox, control_textarea, control_dropdown control_radio, control_checkbox, control_fileupload, control_fullname, control_email and control_datetime. Full List https://www.jotform.com/help/46-quick-overview-of-form-fields/
     /// </summary>
     [JsonPropertyName("type")]
-    public string Type { get; set; }
+    public string Type { get; set; } = null!;
 
     /// <summary>
     /// answer is the actual entry made by the submitter
     /// </summary>
     [JsonPropertyName("answer")]
-    public object Response { get; set; }
+    public object? Response { get; set; }
     
     [JsonPropertyName("prettyFormat")]
-    public string PrettyFormat { get; set; }
+    public string PrettyFormat { get; set; } = null!;
 }
 
 public class GetUserSubmissionsResponse
@@ -51,28 +50,28 @@ public class GetUserSubmissionsResponse
     /// id is the Submission ID
     /// </summary>
     [JsonPropertyName("id")]
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
     [JsonPropertyName("form_id")]
-    public string FormId { get; set; }
+    public string FormId { get; set; } = null!;
 
     /// <summary>
     /// ip address of the submitter
     /// </summary>
     [JsonPropertyName("ip")]
-    public string Ip { get; set; }
+    public string Ip { get; set; } = null!;
 
     /// <summary>
     /// created_at, updated_at: YYYY-MM-DD HH:MM:SS
     /// </summary>
     [JsonPropertyName("created_at")]
-    public string CreatedAt { get; set; }
+    public string CreatedAt { get; set; } = null!;
 
     /// <summary>
     /// created_at, updated_at: YYYY-MM-DD HH:MM:SS
     /// </summary>
     [JsonPropertyName("updated_at")]
-    public string UpdatedAt { get; set; }
+    public string UpdatedAt { get; set; } = null!;
 
     /// <summary>
     /// status can be ACTIVE or OVERQUOTA
@@ -87,5 +86,5 @@ public class GetUserSubmissionsResponse
     public bool New { get; set; }
 
     [JsonPropertyName("answers")]
-    public Dictionary<int, Answer> Answers { get; set; }
+    public Dictionary<int, Answer>? Answers { get; set; }
 }

--- a/Jotform/Endpoints/User/PostUserForms.cs
+++ b/Jotform/Endpoints/User/PostUserForms.cs
@@ -2,6 +2,12 @@
 
 public partial class JotformClient
 {
+    // TODO: formDefinition parameter should be documented properly or better to make it strongly type.
+    /// <summary>
+    /// Create a new form.
+    /// Create new forms with questions, properties and email settings.
+    /// </summary>
+    /// <param name="formDefinition"></param>
     public async Task<JotformResult<Models.Shared.Form>?> PostUserFormsAsync(Dictionary<string, string> formDefinition, CancellationToken cancellationToken = default)
     {
         var formData = new FormDataBuilder();

--- a/Jotform/Endpoints/User/PostUserForms.cs
+++ b/Jotform/Endpoints/User/PostUserForms.cs
@@ -12,10 +12,12 @@ public partial class JotformClient
         }
         
         var response = await _httpClient.PostAsync("user/forms", 
-            formData.Build(), cancellationToken: cancellationToken);
+            formData.Build(), cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
         
-        return await response.Content.ReadFromJsonAsync<JotformResult<Models.Shared.Form>>(_jsonSerializerOptions, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<Models.Shared.Form>>(_jsonSerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/Jotform/Endpoints/User/PostUserLogin.cs
+++ b/Jotform/Endpoints/User/PostUserLogin.cs
@@ -2,6 +2,11 @@
 
 public partial class JotformClient
 {
+    // TODO: Needs to be implemented or deleted.
+    /// <summary>
+    /// Not implemented yet, just throws exception.
+    /// </summary>
+    /// <exception cref="NotSupportedException"></exception>
     public Task PostUserLoginAsync(string username, string password, CancellationToken cancellationToken = default) 
         => throw new NotSupportedException();
 }

--- a/Jotform/Endpoints/User/PostUserRegister.cs
+++ b/Jotform/Endpoints/User/PostUserRegister.cs
@@ -2,6 +2,11 @@
 
 public partial class JotformClient
 {
+    // TODO: Needs to be implemented or deleted.
+    /// <summary>
+    /// Not implemented yet, just throws exception.
+    /// </summary>
+    /// <exception cref="NotSupportedException"></exception>
     public Task PostUserRegisterAsync(string username, string password, string email, CancellationToken cancellationToken = default) 
         => throw new NotSupportedException();
 }

--- a/Jotform/Endpoints/User/PostUserSettings.cs
+++ b/Jotform/Endpoints/User/PostUserSettings.cs
@@ -2,6 +2,18 @@
 
 public partial class JotformClient
 {
+    /// <summary>
+    /// Update User Settings.
+    /// Update user's settings like time zone and language.
+    /// </summary>
+    /// <param name="name">User's name Example: John Smith</param>
+    /// <param name="email">User's email Example: john @smith.com</param>
+    /// <param name="website">User's website Example: www.johnsmith.com</param>
+    /// <param name="timezone">User's time zone Example: UTC</param>
+    /// <param name="company">User's company Example: Interlogy, LLC.</param>
+    /// <param name="securityQuestion">User's security question Example: What was your first car?</param>
+    /// <param name="securityAnswer">User's security answer Example: Ford</param>
+    /// <param name="industry">User's industry Example: Education</param>
     public async Task<JotformResult<UserSettings>?> PostUserSettingsAsync(string? name = null, string? email = null, string? website = null, string? timezone = null, string? company = null, string? securityQuestion = null, string? securityAnswer = null, string? industry = null, 
         CancellationToken cancellationToken = default)
     {

--- a/Jotform/Endpoints/User/PostUserSettings.cs
+++ b/Jotform/Endpoints/User/PostUserSettings.cs
@@ -17,10 +17,12 @@ public partial class JotformClient
             .Build();
 
         var response = await _httpClient.PostAsync("user/settings", 
-            formData, cancellationToken: cancellationToken);
+            formData, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
         
-        return await response.Content.ReadFromJsonAsync<JotformResult<UserSettings>>(_jsonSerializerOptions, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<JotformResult<UserSettings>>(_jsonSerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/Jotform/Endpoints/User/PutUserForms.cs
+++ b/Jotform/Endpoints/User/PutUserForms.cs
@@ -2,6 +2,12 @@
 
 public partial class JotformClient
 {
+    // TODO: formDefinition parameter should be documented properly or better to make it strongly type.
+    /// <summary>
+    /// Create new forms.
+    /// Create new forms with questions, properties and email settings.
+    /// </summary>
+    /// <param name="formDefinition"></param>
     public async Task<JotformResult<Models.Shared.Form>?> PutUserFormsAsync(object formDefinition, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.PutAsJsonAsync("user/forms", formDefinition, _jsonSerializerOptions,

--- a/Jotform/Endpoints/User/PutUserForms.cs
+++ b/Jotform/Endpoints/User/PutUserForms.cs
@@ -1,17 +1,16 @@
-﻿using System.Text;
-using System.Text.Json;
-
-namespace Jotform;
+﻿namespace Jotform;
 
 public partial class JotformClient
 {
     public async Task<JotformResult<Models.Shared.Form>?> PutUserFormsAsync(object formDefinition, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.PutAsJsonAsync("user/forms", formDefinition, _jsonSerializerOptions, 
-            cancellationToken: cancellationToken);
+        var response = await _httpClient.PutAsJsonAsync("user/forms", formDefinition, _jsonSerializerOptions,
+            cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
-        
-        return await response.Content.ReadFromJsonAsync<JotformResult<Models.Shared.Form>>(_jsonSerializerOptions, cancellationToken);
+
+        return await response.Content.ReadFromJsonAsync<JotformResult<Models.Shared.Form>>(_jsonSerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/Jotform/JotformClient.cs
+++ b/Jotform/JotformClient.cs
@@ -39,19 +39,18 @@ public partial class JotformClient
         _httpClient = httpClient;
     }
 
-    public Task<JotformResult<TResult>?> GetResultAsync<TResult>(
+    private Task<JotformResult<TResult>?> GetResultAsync<TResult>(
         string url, CancellationToken cancellation = default)
     {
         return _httpClient.GetFromJsonAsync<JotformResult<TResult>>(
             url, _jsonSerializerOptions, cancellation);
     }
 
-    public Task<PagedJotformResult<TResult>?>
+    private Task<PagedJotformResult<TResult>?>
         GetPagedResultAsync<TResult>(string url,
         CancellationToken cancellation = default)
     {
         return _httpClient.GetFromJsonAsync<PagedJotformResult<
             TResult>>(url, _jsonSerializerOptions, cancellation);
     }
-
 }

--- a/Jotform/Models/Shared/Form.cs
+++ b/Jotform/Models/Shared/Form.cs
@@ -1,4 +1,5 @@
-﻿namespace Jotform.Models.Shared;
+﻿#nullable disable
+namespace Jotform.Models.Shared;
 
 public class Form
 {

--- a/Jotform/Models/Shared/Form.cs
+++ b/Jotform/Models/Shared/Form.cs
@@ -1,17 +1,15 @@
-﻿#nullable disable
-namespace Jotform.Models.Shared;
+﻿namespace Jotform.Models.Shared;
 
 public class Form
 {
-
     [JsonPropertyName("id")]
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
     [JsonPropertyName("username")]
-    public string Username { get; set; }
+    public string Username { get; set; } = null!;
 
     [JsonPropertyName("title")]
-    public string Title { get; set; }
+    public string Title { get; set; } = null!;
 
     [JsonPropertyName("height")]
     public int Height { get; set; }
@@ -20,13 +18,13 @@ public class Form
     public Status Status { get; set; }
 
     [JsonPropertyName("created_at")]
-    public string CreatedAt { get; set; }
+    public string CreatedAt { get; set; } = null!;
 
     [JsonPropertyName("updated_at")]
-    public string UpdatedAt { get; set; }
+    public string UpdatedAt { get; set; } = null!;
 
     [JsonPropertyName("last_submission")]
-    public string LastSubmission { get; set; }
+    public string LastSubmission { get; set; } = null!;
 
     [JsonPropertyName("new")]
     public int New { get; set; }
@@ -44,7 +42,7 @@ public class Form
     public bool Archived { get; set; }
 
     [JsonPropertyName("url")]
-    public string Url { get; set; }
+    public string Url { get; set; } = null!;
     
 }
 

--- a/Jotform/Models/Shared/JotformResult.cs
+++ b/Jotform/Models/Shared/JotformResult.cs
@@ -1,5 +1,5 @@
-﻿using System.Net;
-using System.Text.Json.Serialization;
+﻿#nullable disable
+using System.Net;
 
 namespace Jotform.Models.Shared;
 
@@ -7,10 +7,10 @@ public class JotformResult<TResponse>
 {
     [JsonPropertyName("responseCode")]
     public HttpStatusCode ResponseCode { get; set; }
-    
+
     [JsonPropertyName("message")]
-    public string? Message { get; set; }
-    
+    public string Message { get; set; }
+
     /// <summary>
     /// limit-left is the number of daily api calls you can make.
     /// </summary>

--- a/Jotform/Models/Shared/JotformResult.cs
+++ b/Jotform/Models/Shared/JotformResult.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System.Net;
+﻿using System.Net;
 
 namespace Jotform.Models.Shared;
 
@@ -9,16 +8,17 @@ public class JotformResult<TResponse>
     public HttpStatusCode ResponseCode { get; set; }
 
     [JsonPropertyName("message")]
-    public string Message { get; set; }
+    public string Message { get; set; } = null!;
 
     /// <summary>
     /// limit-left is the number of daily api calls you can make.
     /// </summary>
-    [JsonPropertyName("limit-left")] public int RemainingApiQuota { get; set; }
+    [JsonPropertyName("limit-left")] 
+    public int RemainingApiQuota { get; set; }
 
     [JsonPropertyName("content")]
-    public TResponse Response { get; set; }
+    public TResponse? Response { get; set; }
 
     [JsonPropertyName("duration")]
-    public string Duration { get; set; }
+    public string Duration { get; set; } = null!;
 }

--- a/Jotform/Models/Shared/PagedJotformResult.cs
+++ b/Jotform/Models/Shared/PagedJotformResult.cs
@@ -1,4 +1,5 @@
-﻿namespace Jotform.Models.Shared;
+﻿#nullable disable
+namespace Jotform.Models.Shared;
 
 public class PagedJotformResult<TResponse> : JotformResult<IReadOnlyList<TResponse>>
 {

--- a/Jotform/Models/Shared/PagedJotformResult.cs
+++ b/Jotform/Models/Shared/PagedJotformResult.cs
@@ -1,8 +1,7 @@
-﻿#nullable disable
-namespace Jotform.Models.Shared;
+﻿namespace Jotform.Models.Shared;
 
 public class PagedJotformResult<TResponse> : JotformResult<IReadOnlyList<TResponse>>
 {
     [JsonPropertyName("resultSet")]
-    public PaginationInfo PaginationInfo { get; set; }
+    public PaginationInfo? PaginationInfo { get; set; }
 }

--- a/Jotform/Models/Shared/PaginationInfo.cs
+++ b/Jotform/Models/Shared/PaginationInfo.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-namespace Jotform.Models.Shared;
+﻿namespace Jotform.Models.Shared;
 
 public class PaginationInfo
 {
@@ -8,9 +7,9 @@ public class PaginationInfo
     [JsonPropertyName("limit")]
     public int Limit { get; set; }
     [JsonPropertyName("orderby")]
-    public string OrderBy { get; set; }
+    public string OrderBy { get; set; } = null!;
     [JsonPropertyName("filter")]
-    public object Filter { get; set; }
+    public object? Filter { get; set; }
     [JsonPropertyName("count")]
     public int Count { get; set; }
 }

--- a/Jotform/Models/Shared/PaginationInfo.cs
+++ b/Jotform/Models/Shared/PaginationInfo.cs
@@ -1,4 +1,5 @@
-﻿namespace Jotform.Models.Shared;
+﻿#nullable disable
+namespace Jotform.Models.Shared;
 
 public class PaginationInfo
 {

--- a/Jotform/Models/Shared/Question.cs
+++ b/Jotform/Models/Shared/Question.cs
@@ -72,21 +72,20 @@ public class Question
     public int? Rows { get; set; }
 }
 
-#nullable disable
 public class Sublabels
 {
     [JsonPropertyName("prefix")]
-    public string Prefix { get; set; }
+    public string? Prefix { get; set; }
 
     [JsonPropertyName("first")]
-    public string First { get; set; }
+    public string? First { get; set; }
 
     [JsonPropertyName("middle")]
-    public string Middle { get; set; }
+    public string? Middle { get; set; }
 
     [JsonPropertyName("last")]
-    public string Last { get; set; }
+    public string? Last { get; set; }
 
     [JsonPropertyName("suffix")]
-    public string Suffix { get; set; }
+    public string? Suffix { get; set; }
 }

--- a/Jotform/Models/Shared/Question.cs
+++ b/Jotform/Models/Shared/Question.cs
@@ -1,92 +1,92 @@
 ﻿namespace Jotform.Models.Shared;
 
 public class Question
-    {
-        [JsonPropertyName("hint")]
-        public string? Hint { get; set; }
+{
+    [JsonPropertyName("hint")]
+    public string? Hint { get; set; }
 
-        [JsonPropertyName("labelAlign")]
-        public string? LabelAlign { get; set; }
+    [JsonPropertyName("labelAlign")]
+    public string? LabelAlign { get; set; }
 
-        [JsonPropertyName("name")]
-        public string Name { get; set; }
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
 
-        [JsonPropertyName("order")]
-        public int Order { get; set; }
+    [JsonPropertyName("order")]
+    public int Order { get; set; }
 
-        [JsonPropertyName("qid")]
-        public string Qid { get; set; }
+    [JsonPropertyName("qid")]
+    public string Qid { get; set; } = string.Empty;
 
-        [JsonPropertyName("readonly")]
-        public bool? Readonly { get; set; }
+    [JsonPropertyName("readonly")]
+    public bool? Readonly { get; set; }
 
-        [JsonPropertyName("required")]
-        public bool Required { get; set; }
+    [JsonPropertyName("required")]
+    public bool Required { get; set; }
 
-        [JsonPropertyName("shrink")]
-        public bool? Shrink { get; set; }
+    [JsonPropertyName("shrink")]
+    public bool? Shrink { get; set; }
 
-        [JsonPropertyName("size")]
-        public int? Size { get; set; }
+    [JsonPropertyName("size")]
+    public int? Size { get; set; }
 
-        [JsonPropertyName("text")]
-        public string Text { get; set; }
+    [JsonPropertyName("text")]
+    public string Text { get; set; } = string.Empty;
 
-        /// <summary>
-        /// TODO: Move to enum, once all types are known... Build an example form with all types then run GET?
-        /// </summary>
-        [JsonPropertyName("type")]
-        public string Type { get; set; }
+    /// <summary>
+    /// TODO: Move to enum, once all types are known... Build an example form with all types then run GET?
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
 
-        /// <summary>
-        /// TODO: Possibly move to bool, maybe enum, only know 'None' as a value for now 
-        /// </summary>
-        [JsonPropertyName("validation")]
-        public string? Validation { get; set; }
+    /// <summary>
+    /// TODO: Possibly move to bool, maybe enum, only know 'None' as a value for now 
+    /// </summary>
+    [JsonPropertyName("validation")]
+    public string? Validation { get; set; }
 
-        [JsonPropertyName("middle")]
-        public bool? Middle { get; set; }
+    [JsonPropertyName("middle")]
+    public bool? Middle { get; set; }
 
-        [JsonPropertyName("prefix")]
-        public bool? Prefix { get; set; }
-        
-        /// <summary>
-        /// Can be object Sublabels, or a serialized string of Sublabels
-        /// </summary>
-        [JsonPropertyName("sublabels")]
-        public object Sublabels { get; set; }
+    [JsonPropertyName("prefix")]
+    public bool? Prefix { get; set; }
 
-        [JsonPropertyName("suffix")]
-        public bool? Suffix { get; set; }
+    /// <summary>
+    /// Can be object Sublabels, or a serialized string of Sublabels
+    /// </summary>
+    [JsonPropertyName("sublabels")]
+    public object? Sublabels { get; set; }
 
-        [JsonPropertyName("cols")]
-        public int? Cols { get; set; }
+    [JsonPropertyName("suffix")]
+    public bool? Suffix { get; set; }
 
-        /// <summary>
-        /// TODO: What even is this, only know value: 'None-0'...
-        /// </summary>
-        [JsonPropertyName("entryLimit")]
-        public string? EntryLimit { get; set; }
-        
-        [JsonPropertyName("rows")]
-        public int? Rows { get; set; }
-    }
+    [JsonPropertyName("cols")]
+    public int? Cols { get; set; }
 
-    public class Sublabels
-    {
-        [JsonPropertyName("prefix")]
-        public string Prefix { get; set; }
+    /// <summary>
+    /// TODO: What even is this, only know value: 'None-0'...
+    /// </summary>
+    [JsonPropertyName("entryLimit")]
+    public string? EntryLimit { get; set; }
 
-        [JsonPropertyName("first")]
-        public string First { get; set; }
+    [JsonPropertyName("rows")]
+    public int? Rows { get; set; }
+}
 
-        [JsonPropertyName("middle")]
-        public string Middle { get; set; }
+#nullable disable
+public class Sublabels
+{
+    [JsonPropertyName("prefix")]
+    public string Prefix { get; set; }
 
-        [JsonPropertyName("last")]
-        public string Last { get; set; }
+    [JsonPropertyName("first")]
+    public string First { get; set; }
 
-        [JsonPropertyName("suffix")]
-        public string Suffix { get; set; }
-    }
+    [JsonPropertyName("middle")]
+    public string Middle { get; set; }
 
+    [JsonPropertyName("last")]
+    public string Last { get; set; }
+
+    [JsonPropertyName("suffix")]
+    public string Suffix { get; set; }
+}

--- a/Jotform/Models/Shared/UserSettings.cs
+++ b/Jotform/Models/Shared/UserSettings.cs
@@ -1,4 +1,5 @@
-﻿namespace Jotform.Models.Shared;
+﻿#nullable disable
+namespace Jotform.Models.Shared;
 
 public class UserSettings
 {

--- a/Jotform/Models/Shared/UserSettings.cs
+++ b/Jotform/Models/Shared/UserSettings.cs
@@ -1,31 +1,30 @@
-﻿#nullable disable
-namespace Jotform.Models.Shared;
+﻿namespace Jotform.Models.Shared;
 
 public class UserSettings
 {
     [JsonPropertyName("username")]
-    public string Username { get; set; }
+    public string Username { get; set; } = null!;
 
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     [JsonPropertyName("email")]
-    public string Email { get; set; }
+    public string Email { get; set; } = null!;
 
     [JsonPropertyName("website")]
-    public string Website { get; set; }
+    public string Website { get; set; } = null!;
 
     /// <summary>
     /// time_zone is in IANA format.
     /// </summary>
     [JsonPropertyName("time_zone")]
-    public string TimeZone { get; set; }
+    public string TimeZone { get; set; } = null!;
 
     /// <summary>
     /// account_type list can be seen in Pricing page.
     /// </summary>
     [JsonPropertyName("account_type")]
-    public string AccountType { get; set; }
+    public string AccountType { get; set; } = null!;
 
     /// <summary>
     /// status can be ACTIVE, DELETED or SUSPENDED
@@ -37,40 +36,39 @@ public class UserSettings
     /// created_at, updated_at: YYYY-MM-DD HH:MM:SS
     /// </summary>
     [JsonPropertyName("created_at")]
-    public string CreatedAt { get; set; }
+    public string CreatedAt { get; set; } = null!;
 
     /// <summary>
     /// created_at, updated_at: YYYY-MM-DD HH:MM:SS
     /// </summary>
     [JsonPropertyName("updated_at")]
-    public string UpdatedAt { get; set; }
+    public string UpdatedAt { get; set; } = null!;
 
     [JsonPropertyName("is_verified")]
     public bool? IsVerified { get; set; }
 
     [Obsolete($"Use {nameof(JotformClient.GetUserUsageAsync)}() method instead")]
     [JsonPropertyName("usage")]
-    public string UsageEndpoint { get; set; }
+    public string UsageEndpoint { get; set; } = null!;
 
     [JsonPropertyName("industry")]
-    public string Industry { get; set; }
+    public string Industry { get; set; } = null!;
 
     [JsonPropertyName("securityAnswer")]
-    public string SecurityAnswer { get; set; }
+    public string SecurityAnswer { get; set; } = null!;
 
     [JsonPropertyName("company")]
-    public string Company { get; set; }
+    public string Company { get; set; } = null!;
 
     /// <summary>
     /// Array that is JSON serialized as a string
     /// </summary>
     [JsonPropertyName("webhooks")]
-    public string Webhooks { get; set; }
+    public string Webhooks { get; set; } = null!;
 
     [JsonPropertyName("doNotClone")]
     public bool DoNotClone { get; set; }
 
     [JsonPropertyName("avatarUrl")]
-    public string AvatarUrl { get; set; }
+    public string AvatarUrl { get; set; } = null!;
 }
-


### PR DESCRIPTION
1) Nullability Warning Fixes:
- Added the `#nullable disable` to API result models to get rid of nullable warnings. 
- For some specific properties either added the `string.Empty` or appended `?` based on their chances to be nullable.

2) `ConfigureAwait(false)` Updates: Added the `ConfigureAwait(false)` to all awaited tasks.

3) Doc Comment Updates:
- Added the Doc comments to all endpoints from Jotform API Documentation. 
- In a few places, for now, I've just added `TODO:` where I thought, later on, those input parameters could be strongly typed, or at least documented with proper details.