### PR TITLE
Filter builder updates

### DIFF
--- a/Jotform/JotformClient.cs
+++ b/Jotform/JotformClient.cs
@@ -30,7 +30,7 @@ public partial class JotformClient
             throw new InvalidOperationException($"Cannot create the JotformClient instance, the base address of the httpclient is already set to {httpClient.BaseAddress} .");
 
         var baseUrl = enterpriseSubdomain != null
-            ? $"https://{enterpriseSubdomain}.jotform.com/api"
+            ? $"https://{enterpriseSubdomain}.jotform.com/API/"
             : "https://api.jotform.com";
 
         httpClient.BaseAddress = new Uri(baseUrl);

--- a/Jotform/Models/Shared/JotformFilterBuilder.cs
+++ b/Jotform/Models/Shared/JotformFilterBuilder.cs
@@ -4,14 +4,15 @@ namespace Jotform.Models.Shared;
 
 public class JotformFilterBuilder
 {
-    protected readonly Dictionary<string, object> _fields = new();
+    private const string DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+    protected readonly Dictionary<string, object> _fields = [];
 
     public JotformFilterBuilder AddCriteria<TValue>(
         string field, TValue? value)
     {
         if (value is null) return this;
         if (value is DateTime dateTime)
-            _fields.Add(field, dateTime.ToString("yyyy-MM-dd hh:mm:ss"));
+            _fields.Add(field, dateTime.ToString(DATE_FORMAT));
         else
             _fields.Add(field, value.ToString()!);
 
@@ -57,44 +58,53 @@ public class JotformFilterBuilder
     }
 
     public JotformFilterBuilder AddGreaterThan(
-        string field, DateTime? value, bool minusOneDay = false)
+        string field, DateTime? value, bool minusOneSecond = false)
     {
+        if (value is null) return this;
         return AddCriteria(field, "gt", 
-            minusOneDay ? value?.AddDays(-1.0) : value);
+            minusOneSecond ? value?.AddSeconds(-1.0) : value);
     }
 
     public JotformFilterBuilder AddLessThan(
-        string field, DateTime? value, bool plusOneDay = false)
+        string field, DateTime? value, bool plusOneSecondOrDay = false)
     {
-        return AddCriteria(field, "lt", 
-            plusOneDay ? value?.AddDays(1.0) : value);
+        if (value is null) return this;
+        var dateTime = value.Value;
+        if (plusOneSecondOrDay)
+        {
+            dateTime = dateTime.TimeOfDay == TimeSpan.Zero
+                ? dateTime.AddDays(1)
+                : dateTime.AddSeconds(1);
+
+        }
+        return AddCriteria(field, "lt", dateTime);
     }
 
     public JotformFilterBuilder AddDateRange(
         string field, DateTime? start, DateTime? end, 
-        bool minusOneDayFromStart = true, 
-        bool plusOneDayToEnd = true)
+        bool minusOneSecondFromStart = true, 
+        bool plusOneSecondOrDayToEnd = true)
     {
-        return AddGreaterThan(field, start, minusOneDayFromStart)
-            .AddLessThan(field, end, plusOneDayToEnd);
+        return AddGreaterThan(field, start, minusOneSecondFromStart)
+            .AddLessThan(field, end, plusOneSecondOrDayToEnd);
     }
 
     public JotformFilterBuilder AddCreatedAtDateRange(
         DateTime? start, DateTime? end, 
-        bool minusOneDayFromStart = true,
-        bool plusOneDayToEnd = true)
+        bool minusOneSecondFromStart = true,
+        bool plusOneSecondOrDayToEnd = true)
     {
         return AddDateRange("created_at", start, end,
-            minusOneDayFromStart, plusOneDayToEnd);
+            minusOneSecondFromStart, plusOneSecondOrDayToEnd);
     }
 
     public JotformFilterBuilder AddUpdatedAtDateRange(
         DateTime? start, DateTime? end,
-        bool minusOneDayFromStart = true,
-        bool plusOneDayToEnd = true)
+        bool minusOneSecondFromStart = true,
+        bool plusOneSecondOrDayToEnd = true)
     {
         return AddDateRange("updated_at", start, end,
-            minusOneDayFromStart, plusOneDayToEnd);
+            minusOneSecondFromStart, plusOneSecondOrDayToEnd);
     }
 
     public string? Build()

--- a/tests/Jotform.Tests/JotformFilterBuilderTests.cs
+++ b/tests/Jotform.Tests/JotformFilterBuilderTests.cs
@@ -25,8 +25,8 @@ public class JotformFilterBuilderTests
     const string _lastDateOutput = "2020-12-31 00:00:00";
     const string _firstDateMinus1SecondOutput = 
         "2019-12-31 23:59:59";
-    const string _lastDatePlus1SecondOutput = 
-        "2021-01-01 00:00:01";
+    const string _lastDatePlus1DayOutput = 
+        "2021-01-01 00:00:00";
 
     private const string _fieldName = "field";
     private const string _fieldValue = "value";
@@ -187,13 +187,27 @@ public class JotformFilterBuilderTests
     }
 
     [Fact]
-    public void Build_ReturnsValidJson_If_AddLessThan_IsCalled_WithValidDateAndPlusOneSecondTrue()
+    public void Build_ReturnsValidJson_If_AddLessThan_IsCalled_WithValidDateAndPlusOneSecondOrDayTrue()
     {
         var jsonFilter = GetExpectedFilter(
-            _lastDatePlus1SecondOutput, "lt");
+            _lastDatePlus1DayOutput, "lt");
 
         var builder = new JotformFilterBuilder();
         builder.AddLessThan(_fieldName, _lastDateOf2020, true);
+
+        builder.AssertBuildReturnsJson(jsonFilter);
+    }
+
+    [Fact]
+    public void Build_ReturnsValidJson_If_AddLessThan_IsCalled_WithValidDateAndPlusOneSecondOrDayTrue_2()
+    {
+        var jsonFilter = GetExpectedFilter(
+            _lastDatePlus1DayOutput, "lt");
+        var lastDateOf2020AtLastSecond = _lastDateOf2020
+            .AddDays(1).AddSeconds(-1);
+
+        var builder = new JotformFilterBuilder();
+        builder.AddLessThan(_fieldName, lastDateOf2020AtLastSecond, true);
 
         builder.AssertBuildReturnsJson(jsonFilter);
     }

--- a/tests/Jotform.Tests/JotformFilterBuilderTests.cs
+++ b/tests/Jotform.Tests/JotformFilterBuilderTests.cs
@@ -2,13 +2,27 @@
 
 namespace Jotform.Tests;
 
+file static class AssertHelper
+{
+    internal static void AssertBuildReturnsNull(
+        this JotformFilterBuilder builder)
+    {
+        builder.Build().Should().BeNull();
+    }
+
+    internal static void AssertBuildReturnsJson(this JotformFilterBuilder builder, string jsonFilter)
+    {
+        builder.Build().Should().Be(jsonFilter);
+    }
+}
+
 public class JotformFilterBuilderTests
 {
     [Fact]
     public void Build_ReturnsNull_If_NoOtherMethodIsCalled()
     {
         var builder = new JotformFilterBuilder();
-        builder.Build().Should().BeNull();
+        builder.AssertBuildReturnsNull();
     }
 
     [Fact]
@@ -23,7 +37,7 @@ public class JotformFilterBuilderTests
         builder.AddCriteria("field2", field2);
         builder.AddCriteria("field3", field3);
         
-        builder.Build().Should().BeNull();
+        builder.AssertBuildReturnsNull();
     }
 
     [Fact]
@@ -35,7 +49,7 @@ public class JotformFilterBuilderTests
 
         builder.AddCriteria(nameof(field), field);
 
-        builder.Build().Should().Be(jsonFilter);
+        builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
@@ -47,7 +61,7 @@ public class JotformFilterBuilderTests
 
         builder.AddCriteria(nameof(field), field);
 
-        builder.Build().Should().Be(jsonFilter);
+        builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
@@ -59,7 +73,7 @@ public class JotformFilterBuilderTests
 
         builder.AddCriteria(nameof(field), field);
 
-        builder.Build().Should().Be(jsonFilter);
+        builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
@@ -72,7 +86,7 @@ public class JotformFilterBuilderTests
 
         builder.AddCriteria(nameof(field), comparision, field);
 
-        builder.Build().Should().Be(jsonFilter);
+        builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
@@ -84,7 +98,7 @@ public class JotformFilterBuilderTests
 
         builder.AddGreaterThan(nameof(field), field);
 
-        builder.Build().Should().Be(jsonFilter);
+        builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
@@ -96,7 +110,7 @@ public class JotformFilterBuilderTests
 
         builder.AddLessThan(nameof(field), field);
 
-        builder.Build().Should().Be(jsonFilter);
+        builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
@@ -108,7 +122,7 @@ public class JotformFilterBuilderTests
 
         builder.AddNotEqualTo(nameof(field), field);
 
-        builder.Build().Should().Be(jsonFilter);
+        builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
@@ -120,7 +134,7 @@ public class JotformFilterBuilderTests
 
         builder.AddMatches(nameof(field), field);
 
-        builder.Build().Should().Be(jsonFilter);
+        builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
@@ -132,7 +146,7 @@ public class JotformFilterBuilderTests
         
         builder.AddGreaterThan(nameof(field), field);
 
-        builder.Build().Should().Be(jsonFilter);
+        builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
@@ -144,7 +158,7 @@ public class JotformFilterBuilderTests
 
         builder.AddGreaterThan(nameof(field), field, true);
 
-        builder.Build().Should().Be(jsonFilter);
+        builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
@@ -156,7 +170,7 @@ public class JotformFilterBuilderTests
 
         builder.AddLessThan(nameof(field), field);
 
-        builder.Build().Should().Be(jsonFilter);
+        builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
@@ -168,6 +182,6 @@ public class JotformFilterBuilderTests
 
         builder.AddLessThan(nameof(field), field, true);
 
-        builder.Build().Should().Be(jsonFilter);
+        builder.AssertBuildReturnsJson(jsonFilter);
     }
 }

--- a/tests/Jotform.Tests/JotformFilterBuilderTests.cs
+++ b/tests/Jotform.Tests/JotformFilterBuilderTests.cs
@@ -17,7 +17,28 @@ file static class AssertHelper
 }
 
 public class JotformFilterBuilderTests
-{
+{   
+    private static DateTime _firstDateOf2020 = new(2020, 1, 1);
+    private static DateTime _lastDateOf2020 = new(2020, 12, 31);
+
+    const string _firstDateOutput = "2020-01-01 00:00:00";
+    const string _lastDateOutput = "2020-12-31 00:00:00";
+    const string _firstDateMinus1SecondOutput = 
+        "2019-12-31 23:59:59";
+    const string _lastDatePlus1SecondOutput = 
+        "2021-01-01 00:00:01";
+
+    private const string _fieldName = "field";
+    private const string _fieldValue = "value";
+
+    private static string GetExpectedFilter(string fieldValue, 
+        string? comparision = null)
+    {
+        string fieldName = comparision is null 
+            ? _fieldName : $"{_fieldName}:{comparision}";
+        return $@"{{""{fieldName}"":""{fieldValue}""}}";
+    }
+
     [Fact]
     public void Build_ReturnsNull_If_NoOtherMethodIsCalled()
     {
@@ -28,26 +49,25 @@ public class JotformFilterBuilderTests
     [Fact]
     public void Build_ReturnsNull_If_OtherMethodsAreCalledWithNulls()
     {
-        var builder = new JotformFilterBuilder();
         string? field1 = null;
         int? field2 = null;
         decimal? field3 = null;
-        
-        builder.AddCriteria("field1", field1);
-        builder.AddCriteria("field2", field2);
-        builder.AddCriteria("field3", field3);
+
+        var builder = new JotformFilterBuilder();        
+        builder.AddCriteria(nameof(field1), field1);
+        builder.AddCriteria(nameof(field2), field2);
+        builder.AddCriteria(nameof(field3), field3);
         
         builder.AssertBuildReturnsNull();
     }
 
     [Fact]
-    public void Build_ReturnsValidJson_If_AddCriteria_IsCalledWithNonEmptyString()
+    public void Build_ReturnsValidJson_If_AddCriteria_IsCalledWithNonNullString()
     {
-        var builder = new JotformFilterBuilder();
-        string? field = "value";
-        var jsonFilter = @"{""field"":""value""}";
+        var jsonFilter = GetExpectedFilter(_fieldValue);
 
-        builder.AddCriteria(nameof(field), field);
+        var builder = new JotformFilterBuilder();
+        builder.AddCriteria(_fieldName, _fieldValue);
 
         builder.AssertBuildReturnsJson(jsonFilter);
     }
@@ -55,11 +75,11 @@ public class JotformFilterBuilderTests
     [Fact]
     public void Build_ReturnsValidJson_If_AddCriteria_IsCalledWithValidInteger()
     {
-        var builder = new JotformFilterBuilder();
-        int? field = 0;
-        var jsonFilter = @"{""field"":""0""}";
+        int? fieldValue = 0;
+        var jsonFilter = GetExpectedFilter("0");
 
-        builder.AddCriteria(nameof(field), field);
+        var builder = new JotformFilterBuilder();        
+        builder.AddCriteria(_fieldName, fieldValue);
 
         builder.AssertBuildReturnsJson(jsonFilter);
     }
@@ -67,72 +87,67 @@ public class JotformFilterBuilderTests
     [Fact]
     public void Build_ReturnsValidJson_If_AddCriteria_IsCalledWithValidDecimal()
     {
-        var builder = new JotformFilterBuilder();
-        decimal? field = 0.1M;
-        var jsonFilter = @"{""field"":""0.1""}";
+        decimal? fieldValue = 0.1M;
+        var jsonFilter = GetExpectedFilter("0.1");
 
-        builder.AddCriteria(nameof(field), field);
+        var builder = new JotformFilterBuilder();
+        builder.AddCriteria(_fieldName, fieldValue);
 
         builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
-    public void Build_ReturnsValidJson_If_AddCriteria_WithComparisionModifier_IsCalledWithNonEmptyString()
+    public void Build_ReturnsValidJson_If_AddCriteria_WithComparisionModifier_IsCalledWithNonNullString()
     {
-        var builder = new JotformFilterBuilder();
         const string comparision = "eq";
-        string? field = "value";
-        var jsonFilter = @"{""field:eq"":""value""}";
+        var jsonFilter = GetExpectedFilter(_fieldValue, comparision);
 
-        builder.AddCriteria(nameof(field), comparision, field);
-
-        builder.AssertBuildReturnsJson(jsonFilter);
-    }
-
-    [Fact]
-    public void Build_ReturnsValidJson_If_AddGreaterThan_IsCalledWithNonEmptyString()
-    {
-        var builder = new JotformFilterBuilder();
-        string? field = "value";
-        var jsonFilter = @"{""field:gt"":""value""}";
-
-        builder.AddGreaterThan(nameof(field), field);
+        var builder = new JotformFilterBuilder();        
+        builder.AddCriteria(_fieldName, comparision, _fieldValue);
 
         builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
-    public void Build_ReturnsValidJson_If_AddLessThan_IsCalledWithNonEmptyString()
+    public void Build_ReturnsValidJson_If_AddGreaterThan_IsCalledWithNonNullString()
     {
-        var builder = new JotformFilterBuilder();
-        string? field = "value";
-        var jsonFilter = @"{""field:lt"":""value""}";
+        var jsonFilter = GetExpectedFilter(_fieldValue, "gt");
 
-        builder.AddLessThan(nameof(field), field);
+        var builder = new JotformFilterBuilder();
+        builder.AddGreaterThan(_fieldName, _fieldValue);
 
         builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
-    public void Build_ReturnsValidJson_If_AddNotEqualTo_IsCalledWithNonEmptyString()
+    public void Build_ReturnsValidJson_If_AddLessThan_IsCalledWithNonNullString()
     {
-        var builder = new JotformFilterBuilder();
-        string? field = "value";
-        var jsonFilter = @"{""field:ne"":""value""}";
+        var jsonFilter = GetExpectedFilter(_fieldValue, "lt");
 
-        builder.AddNotEqualTo(nameof(field), field);
+        var builder = new JotformFilterBuilder();
+        builder.AddLessThan(_fieldName, _fieldValue);
 
         builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
-    public void Build_ReturnsValidJson_If_AddMatches_IsCalledWithNonEmptyString()
+    public void Build_ReturnsValidJson_If_AddNotEqualTo_IsCalledWithNonNullString()
     {
-        var builder = new JotformFilterBuilder();
-        string? field = "value";
-        var jsonFilter = @"{""field:matches"":""value""}";
+        var jsonFilter = GetExpectedFilter(_fieldValue, "ne");
 
-        builder.AddMatches(nameof(field), field);
+        var builder = new JotformFilterBuilder();       
+        builder.AddNotEqualTo(_fieldName, _fieldValue);
+
+        builder.AssertBuildReturnsJson(jsonFilter);
+    }
+
+    [Fact]
+    public void Build_ReturnsValidJson_If_AddMatches_IsCalledWithNonNullString()
+    {
+        var jsonFilter = GetExpectedFilter(_fieldValue, "matches");
+
+        var builder = new JotformFilterBuilder();
+        builder.AddMatches(_fieldName, _fieldValue);
 
         builder.AssertBuildReturnsJson(jsonFilter);
     }
@@ -140,23 +155,22 @@ public class JotformFilterBuilderTests
     [Fact]
     public void Build_ReturnsValidJson_If_AddGreaterThan_IsCalledWithValidDate()
     {
-        var builder = new JotformFilterBuilder();
-        DateTime? field = new DateTime(2024, 1, 1);
-        var jsonFilter = @$"{{""field:gt"":""2024-01-01 12:00:00""}}";
-        
-        builder.AddGreaterThan(nameof(field), field);
+        var jsonFilter = GetExpectedFilter(_firstDateOutput, "gt");
+
+        var builder = new JotformFilterBuilder();        
+        builder.AddGreaterThan(_fieldName, _firstDateOf2020);
 
         builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
-    public void Build_ReturnsValidJson_If_AddGreaterThan_IsCalledWithValidDateAndMinusOneDayTrue()
+    public void Build_ReturnsValidJson_If_AddGreaterThan_IsCalledWithValidDateAndMinusOneSecondTrue()
     {
-        var builder = new JotformFilterBuilder();
-        DateTime? field = new DateTime(2024, 1, 2);
-        var jsonFilter = @$"{{""field:gt"":""2024-01-01 12:00:00""}}";
+        var jsonFilter = GetExpectedFilter(
+            _firstDateMinus1SecondOutput, "gt");
 
-        builder.AddGreaterThan(nameof(field), field, true);
+        var builder = new JotformFilterBuilder();
+        builder.AddGreaterThan(_fieldName, _firstDateOf2020, true);
 
         builder.AssertBuildReturnsJson(jsonFilter);
     }
@@ -164,23 +178,22 @@ public class JotformFilterBuilderTests
     [Fact]
     public void Build_ReturnsValidJson_If_AddLessThan_IsCalledWithValidDate()
     {
-        var builder = new JotformFilterBuilder();
-        DateTime? field = new DateTime(2024, 1, 1);
-        var jsonFilter = @$"{{""field:lt"":""2024-01-01 12:00:00""}}";
+        var jsonFilter = GetExpectedFilter(_lastDateOutput, "lt");
 
-        builder.AddLessThan(nameof(field), field);
+        var builder = new JotformFilterBuilder();       
+        builder.AddLessThan(_fieldName, _lastDateOf2020);
 
         builder.AssertBuildReturnsJson(jsonFilter);
     }
 
     [Fact]
-    public void Build_ReturnsValidJson_If_AddLessThan_IsCalledWithValidDateAndPlusOneDayTrue()
+    public void Build_ReturnsValidJson_If_AddLessThan_IsCalled_WithValidDateAndPlusOneSecondTrue()
     {
-        var builder = new JotformFilterBuilder();
-        DateTime? field = new DateTime(2024, 1, 1);
-        var jsonFilter = @$"{{""field:lt"":""2024-01-02 12:00:00""}}";
+        var jsonFilter = GetExpectedFilter(
+            _lastDatePlus1SecondOutput, "lt");
 
-        builder.AddLessThan(nameof(field), field, true);
+        var builder = new JotformFilterBuilder();
+        builder.AddLessThan(_fieldName, _lastDateOf2020, true);
 
         builder.AssertBuildReturnsJson(jsonFilter);
     }


### PR DESCRIPTION
- Updated some tests to cover the changes.
- Updated the date time format to be 24-hour format as that's the format jotform filter string expects.
- Fixed the date filters logic, currently jotform filter commands don't support GreaterThanOrEqualTo (>=) and LessThanOrEqualTo (<=), which means the date range filter requires adjusting the dates. To make the date range filter convenient I last time added optional flags for adding/subtracting one day from dates but that only worked if the time is zero in the dates, so this update is an attempt to address that limitation by subtracting only 1 second and adding either 1 second or day depends if the time is included in the date.